### PR TITLE
Bump max go version

### DIFF
--- a/.github/actions/vars/action.yml
+++ b/.github/actions/vars/action.yml
@@ -3,13 +3,13 @@ description: "Exposes versions for common tools used in workflows"
 outputs:
   go_version:
     description: "Go version (latest stable)"
-    value: '1.25.6'
+    value: '1.25.7'
   go_version_min:
     description: "Go version (minimum supported)"
     value: '1.24.0'
   go_versions_matrix:
     description: "Go versions for matrix testing (JSON array)"
-    value: '["1.24.0", "1.25.6"]'
+    value: '["1.24.0", "1.25.7"]'
   golangci_lint_version:
     description: "golangci-lint version"
     value: 'v2.8.0'


### PR DESCRIPTION
This pull request updates the Go version used in GitHub Actions workflow variables to the latest stable release.

- Workflow tool version updates:
  * [`.github/actions/vars/action.yml`](diffhunk://#diff-d7920ab7123dbdb5ab0af149fd115e8c71b1287f3fb000728deb03de06a0aa2aL6-R12): Updated the `go_version` output from `1.25.6` to `1.25.7`, and updated the `go_versions_matrix` output to include `1.25.7` instead of `1.25.6`.