### PR TITLE
feat: detect errors.Is/As, suggest qt.ErrorIs/qt.ErrorAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ The tool helps enforce best practices for quicktest usage by detecting suboptima
 - Detecting `strings.Contains(x, y), qt.IsFalse` and suggesting `x, qt.Not(qt.Contains), y`
 - Detecting `slices.Contains(x, y), qt.IsTrue` and suggesting `x, qt.Contains, y`
 - Detecting `slices.Contains(x, y), qt.IsFalse` and suggesting `x, qt.Not(qt.Contains), y`
+- Detecting `errors.Is(err, target), qt.IsTrue` and suggesting `err, qt.ErrorIs, target`
+- Detecting `errors.Is(err, target), qt.IsFalse` and suggesting `err, qt.Not(qt.ErrorIs), target`
+- Detecting `errors.As(err, &target), qt.IsTrue` and suggesting `err, qt.ErrorAs, &target`
+- Detecting `errors.As(err, &target), qt.IsFalse` and suggesting `err, qt.Not(qt.ErrorAs), &target`
 - Detecting `if err != nil { t.Fatal[f](...) }` and suggesting `c.Assert(err, qt.IsNil, qt.Commentf(...))`
 - Detecting `if err != nil { t.Error[f](...) }` and suggesting `c.Check(err, qt.IsNil, qt.Commentf(...))`
 
@@ -109,7 +113,7 @@ golangci-lint run --fix
 
 ## Rules
 
-Most rules support **automatic fixing** with the `-fix` flag. The `if err != nil` rules (7 and 8) report diagnostics only — no automatic fix is provided.
+Most rules support **automatic fixing** with the `-fix` flag. The `if err != nil` rules (9 and 10) report diagnostics only — no automatic fix is provided.
 
 ### 1. Use `qt.IsNotNil` instead of `qt.Not(qt.IsNil)`
 
@@ -290,7 +294,37 @@ qtlint: use qt.Contains instead of slices.Contains(x, y), qt.IsTrue
 qtlint: use qt.Not(qt.Contains) instead of slices.Contains(x, y), qt.IsFalse
 ```
 
-### 8. Use `c.Assert(err, qt.IsNil)` instead of `if err != nil { t.Fatal[f](...) }`
+### 8. Use `qt.ErrorIs` / `qt.ErrorAs` instead of `errors.Is(...)` / `errors.As(...)` with `qt.IsTrue` / `qt.IsFalse`
+
+The quicktest library provides `qt.ErrorIs` and `qt.ErrorAs` as direct checkers for `errors.Is` and `errors.As`. Wrapping those calls in `qt.IsTrue`/`qt.IsFalse` hides the intent and produces less informative failure messages.
+
+**Bad:**
+```go
+c.Assert(errors.Is(err, services.ErrClosedLoanFieldImmutable), qt.IsTrue)
+qt.Assert(t, errors.Is(err, fs.ErrNotExist), qt.IsFalse)
+c.Assert(errors.As(err, &target), qt.IsTrue)
+qt.Assert(t, errors.As(err, &target), qt.IsFalse)
+```
+
+**Good:**
+```go
+c.Assert(err, qt.ErrorIs, services.ErrClosedLoanFieldImmutable)
+qt.Assert(t, err, qt.Not(qt.ErrorIs), fs.ErrNotExist)
+c.Assert(err, qt.ErrorAs, &target)
+qt.Assert(t, err, qt.Not(qt.ErrorAs), &target)
+```
+
+**Auto-fix:** ✅ Automatically replaces `errors.Is(err, target), qt.IsTrue` with `err, qt.ErrorIs, target` (and the `qt.IsFalse` / `errors.As` variants in the same way)
+
+**Error messages:**
+```
+qtlint: use qt.ErrorIs instead of errors.Is(err, target), qt.IsTrue
+qtlint: use qt.Not(qt.ErrorIs) instead of errors.Is(err, target), qt.IsFalse
+qtlint: use qt.ErrorAs instead of errors.As(err, target), qt.IsTrue
+qtlint: use qt.Not(qt.ErrorAs) instead of errors.As(err, target), qt.IsFalse
+```
+
+### 9. Use `c.Assert(err, qt.IsNil)` instead of `if err != nil { t.Fatal[f](...) }`
 
 When a `*qt.C` variable and a quicktest import are in scope, the pattern `if err != nil { t.Fatal(...) }` should be replaced with a `c.Assert` call.
 
@@ -318,9 +352,9 @@ qtlint: use c.Assert(err, qt.IsNil) instead of t.Fatal(...)
 qtlint: use c.Assert(err, qt.IsNil, qt.Commentf(...)) instead of t.Fatalf(...)
 ```
 
-### 9. Use `c.Check(err, qt.IsNil)` instead of `if err != nil { t.Error[f](...) }`
+### 10. Use `c.Check(err, qt.IsNil)` instead of `if err != nil { t.Error[f](...) }`
 
-Same as rule 7, but for `t.Error`/`t.Errorf` which maps to `c.Check` (non-fatal assertion).
+Same as rule 9, but for `t.Error`/`t.Errorf` which maps to `c.Check` (non-fatal assertion).
 
 **Bad:**
 ```go

--- a/qtlint.go
+++ b/qtlint.go
@@ -16,6 +16,10 @@
 //   - strings.Contains(x, y), qt.IsFalse which should be replaced with x, qt.Not(qt.Contains), y
 //   - slices.Contains(x, y), qt.IsTrue which should be replaced with x, qt.Contains, y
 //   - slices.Contains(x, y), qt.IsFalse which should be replaced with x, qt.Not(qt.Contains), y
+//   - errors.Is(err, target), qt.IsTrue which should be replaced with err, qt.ErrorIs, target
+//   - errors.Is(err, target), qt.IsFalse which should be replaced with err, qt.Not(qt.ErrorIs), target
+//   - errors.As(err, &target), qt.IsTrue which should be replaced with err, qt.ErrorAs, &target
+//   - errors.As(err, &target), qt.IsFalse which should be replaced with err, qt.Not(qt.ErrorAs), &target
 //   - if err != nil { t.Fatal[f](...) } which should be replaced with c.Assert(err, qt.IsNil, qt.Commentf(...))
 //   - if err != nil { t.Error[f](...) } which should be replaced with c.Check(err, qt.IsNil, qt.Commentf(...))
 //
@@ -114,6 +118,9 @@ func checkQuicktestCall(pass *analysis.Pass, call *ast.CallExpr) {
 
 	// Check for strings.Contains(x, y) or slices.Contains(x, y) with qt.IsTrue/qt.IsFalse pattern
 	checkContainsPattern(pass, call)
+
+	// Check for errors.Is(err, target) or errors.As(err, &target) with qt.IsTrue/qt.IsFalse pattern.
+	checkErrorIsAsPattern(pass, call)
 }
 
 // getCheckerArg extracts the checker argument from a quicktest assertion call.
@@ -792,6 +799,140 @@ func checkContainsPattern(pass *analysis.Pass, call *ast.CallExpr) {
 		},
 	}
 	pass.Report(diagnostic)
+}
+
+// checkErrorIsAsPattern checks if the pattern is errors.Is(err, target) or
+// errors.As(err, &target) with qt.IsTrue or qt.IsFalse and suggests using
+// qt.ErrorIs / qt.ErrorAs (or their negations via qt.Not).
+func checkErrorIsAsPattern(pass *analysis.Pass, call *ast.CallExpr) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	// Determine the position of the "got" argument based on whether it's
+	// qt.Assert(t, got, checker, ...) or c.Assert(got, checker, ...).
+	gotArgIndex := 0
+	if isPackageQualified(pass, sel) {
+		gotArgIndex = 1
+	}
+
+	if len(call.Args) < gotArgIndex+2 {
+		return
+	}
+
+	gotArg := call.Args[gotArgIndex]
+	checkerArg := call.Args[gotArgIndex+1]
+
+	// gotArg must be a call to errors.Is or errors.As.
+	fnCall, ok := gotArg.(*ast.CallExpr)
+	if !ok {
+		return
+	}
+
+	fnSel, ok := fnCall.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	var newCheckerName string
+	switch fnSel.Sel.Name {
+	case "Is":
+		newCheckerName = "ErrorIs"
+	case "As":
+		newCheckerName = "ErrorAs"
+	default:
+		return
+	}
+
+	// Verify the receiver refers to the standard "errors" package.
+	pkgIdent, ok := fnSel.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+	obj := pass.TypesInfo.Uses[pkgIdent]
+	if obj == nil {
+		return
+	}
+	pkgName, ok := obj.(*types.PkgName)
+	if !ok {
+		return
+	}
+	if pkgName.Imported().Path() != "errors" {
+		return
+	}
+
+	// errors.Is/As take exactly two arguments.
+	if len(fnCall.Args) != 2 {
+		return
+	}
+
+	// The checker must be qt.IsTrue or qt.IsFalse.
+	checkerSel, ok := checkerArg.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+	checkerName := checkerSel.Sel.Name
+	if checkerName != "IsTrue" && checkerName != "IsFalse" {
+		return
+	}
+	if !isPackageQualified(pass, checkerSel) {
+		return
+	}
+	qtPkgIdent, ok := checkerSel.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+
+	firstText, ok := formatExpr(pass, fnCall.Args[0])
+	if !ok {
+		return
+	}
+	secondText, ok := formatExpr(pass, fnCall.Args[1])
+	if !ok {
+		return
+	}
+
+	// errors.Is/As(...), qt.IsTrue  -> err, qt.ErrorIs/ErrorAs, target
+	// errors.Is/As(...), qt.IsFalse -> err, qt.Not(qt.ErrorIs/ErrorAs), target
+	usePositive := checkerName == "IsTrue"
+	pkgNameStr := pkgIdent.Name // e.g., "errors" or an alias
+
+	var newCheckerText, message, fixMessage string
+	if usePositive {
+		newCheckerText = qtPkgIdent.Name + "." + newCheckerName + ", " + secondText
+		message = fmt.Sprintf("qtlint: use qt.%s instead of %s.%s(err, target), qt.IsTrue",
+			newCheckerName, pkgNameStr, fnSel.Sel.Name)
+		fixMessage = fmt.Sprintf("Replace with qt.%s", newCheckerName)
+	} else {
+		newCheckerText = qtPkgIdent.Name + ".Not(" + qtPkgIdent.Name + "." + newCheckerName + "), " + secondText
+		message = fmt.Sprintf("qtlint: use qt.Not(qt.%s) instead of %s.%s(err, target), qt.IsFalse",
+			newCheckerName, pkgNameStr, fnSel.Sel.Name)
+		fixMessage = fmt.Sprintf("Replace with qt.Not(qt.%s)", newCheckerName)
+	}
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     gotArg.Pos(),
+		End:     checkerArg.End(),
+		Message: message,
+		SuggestedFixes: []analysis.SuggestedFix{
+			{
+				Message: fixMessage,
+				TextEdits: []analysis.TextEdit{
+					{
+						Pos:     gotArg.Pos(),
+						End:     gotArg.End(),
+						NewText: []byte(firstText),
+					},
+					{
+						Pos:     checkerArg.Pos(),
+						End:     checkerArg.End(),
+						NewText: []byte(newCheckerText),
+					},
+				},
+			},
+		},
+	})
 }
 
 func stripParens(expr ast.Expr) ast.Expr {

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -16,4 +16,6 @@ func TestFixes(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "nilcmpfix")
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "strcontainsfix")
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "aliascontainsfix")
+	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "errorisfix")
+	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "aliaserrorsfix")
 }

--- a/qtlint_test.go
+++ b/qtlint_test.go
@@ -55,4 +55,14 @@ func TestAnalyzer(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		analysistest.Run(t, testdata, analyzer, "aliascontains")
 	})
+
+	t.Run("errors.Is and errors.As patterns", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		analysistest.Run(t, testdata, analyzer, "erroris")
+	})
+
+	t.Run("errors.Is and errors.As patterns with package aliases", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		analysistest.Run(t, testdata, analyzer, "aliaserrors")
+	})
 }

--- a/testdata/src/aliaserrors/aliaserrors.go
+++ b/testdata/src/aliaserrors/aliaserrors.go
@@ -1,0 +1,34 @@
+package aliaserrors
+
+import (
+	"testing"
+
+	myerrors "errors"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var ErrSentinel = myerrors.New("sentinel")
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+// Test case: errors.Is with alias.
+func TestErrorsIsWithAlias(t *testing.T) {
+	c := qt.New(t)
+	err := ErrSentinel
+
+	qt.Assert(t, myerrors.Is(err, ErrSentinel), qt.IsTrue) // want "qtlint: use qt.ErrorIs instead of myerrors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(myerrors.Is(err, ErrSentinel), qt.IsFalse)    // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of myerrors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: errors.As with alias.
+func TestErrorsAsWithAlias(t *testing.T) {
+	c := qt.New(t)
+	err := ErrSentinel
+	var ce *customErr
+
+	qt.Assert(t, myerrors.As(err, &ce), qt.IsTrue) // want "qtlint: use qt.ErrorAs instead of myerrors.As\\(err, target\\), qt.IsTrue"
+	c.Assert(myerrors.As(err, &ce), qt.IsFalse)    // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of myerrors.As\\(err, target\\), qt.IsFalse"
+}

--- a/testdata/src/aliaserrorsfix/aliaserrorsfix.go
+++ b/testdata/src/aliaserrorsfix/aliaserrorsfix.go
@@ -1,0 +1,34 @@
+package aliaserrorsfix
+
+import (
+	"testing"
+
+	myerrors "errors"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var ErrSentinel = myerrors.New("sentinel")
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+// Test case: errors.Is with alias.
+func TestErrorsIsWithAlias(t *testing.T) {
+	c := qt.New(t)
+	err := ErrSentinel
+
+	qt.Assert(t, myerrors.Is(err, ErrSentinel), qt.IsTrue) // want "qtlint: use qt.ErrorIs instead of myerrors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(myerrors.Is(err, ErrSentinel), qt.IsFalse)    // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of myerrors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: errors.As with alias.
+func TestErrorsAsWithAlias(t *testing.T) {
+	c := qt.New(t)
+	err := ErrSentinel
+	var ce *customErr
+
+	qt.Assert(t, myerrors.As(err, &ce), qt.IsTrue) // want "qtlint: use qt.ErrorAs instead of myerrors.As\\(err, target\\), qt.IsTrue"
+	c.Assert(myerrors.As(err, &ce), qt.IsFalse)    // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of myerrors.As\\(err, target\\), qt.IsFalse"
+}

--- a/testdata/src/aliaserrorsfix/aliaserrorsfix.go.golden
+++ b/testdata/src/aliaserrorsfix/aliaserrorsfix.go.golden
@@ -1,0 +1,34 @@
+package aliaserrorsfix
+
+import (
+	"testing"
+
+	myerrors "errors"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var ErrSentinel = myerrors.New("sentinel")
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+// Test case: errors.Is with alias.
+func TestErrorsIsWithAlias(t *testing.T) {
+	c := qt.New(t)
+	err := ErrSentinel
+
+	qt.Assert(t, err, qt.ErrorIs, ErrSentinel)     // want "qtlint: use qt.ErrorIs instead of myerrors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(err, qt.Not(qt.ErrorIs), ErrSentinel) // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of myerrors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: errors.As with alias.
+func TestErrorsAsWithAlias(t *testing.T) {
+	c := qt.New(t)
+	err := ErrSentinel
+	var ce *customErr
+
+	qt.Assert(t, err, qt.ErrorAs, &ce)     // want "qtlint: use qt.ErrorAs instead of myerrors.As\\(err, target\\), qt.IsTrue"
+	c.Assert(err, qt.Not(qt.ErrorAs), &ce) // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of myerrors.As\\(err, target\\), qt.IsFalse"
+}

--- a/testdata/src/erroris/erroris.go
+++ b/testdata/src/erroris/erroris.go
@@ -1,0 +1,114 @@
+package erroris
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var ErrSentinel = errors.New("sentinel")
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+func makeErr() error {
+	return ErrSentinel
+}
+
+// Test case: errors.Is(err, target), qt.IsTrue should be replaced with err, qt.ErrorIs, target.
+func TestErrorsIsIsTrue(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, errors.Is(err, ErrSentinel), qt.IsTrue) // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(errors.Is(err, ErrSentinel), qt.IsTrue)     // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+}
+
+// Test case: errors.Is(err, target), qt.IsFalse should be replaced with err, qt.Not(qt.ErrorIs), target.
+func TestErrorsIsIsFalse(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, errors.Is(err, fs.ErrNotExist), qt.IsFalse) // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+	c.Assert(errors.Is(err, fs.ErrNotExist), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: qt.Check should also be checked.
+func TestCheckErrorsIs(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Check(t, errors.Is(err, ErrSentinel), qt.IsTrue)     // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+	c.Check(errors.Is(err, ErrSentinel), qt.IsTrue)         // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+	qt.Check(t, errors.Is(err, fs.ErrNotExist), qt.IsFalse) // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+	c.Check(errors.Is(err, fs.ErrNotExist), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: errors.As(err, &target), qt.IsTrue should be replaced with err, qt.ErrorAs, &target.
+func TestErrorsAsIsTrue(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	qt.Assert(t, errors.As(err, &ce), qt.IsTrue) // want "qtlint: use qt.ErrorAs instead of errors.As\\(err, target\\), qt.IsTrue"
+	c.Assert(errors.As(err, &ce), qt.IsTrue)     // want "qtlint: use qt.ErrorAs instead of errors.As\\(err, target\\), qt.IsTrue"
+}
+
+// Test case: errors.As(err, &target), qt.IsFalse should be replaced with err, qt.Not(qt.ErrorAs), &target.
+func TestErrorsAsIsFalse(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	qt.Assert(t, errors.As(err, &ce), qt.IsFalse) // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of errors.As\\(err, target\\), qt.IsFalse"
+	c.Assert(errors.As(err, &ce), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of errors.As\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: complex target expressions are preserved verbatim.
+func TestErrorsIsComplexTarget(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	targets := []error{ErrSentinel, fs.ErrNotExist}
+
+	qt.Assert(t, errors.Is(err, targets[0]), qt.IsTrue) // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(errors.Is(err, targets[1]), qt.IsFalse)    // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Negative test cases: patterns that should NOT trigger the rule.
+
+// Using qt.ErrorIs / qt.ErrorAs directly is correct.
+func TestErrorIsDirect(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	c.Assert(err, qt.ErrorIs, ErrSentinel)
+	qt.Assert(t, err, qt.ErrorIs, ErrSentinel)
+	c.Assert(err, qt.ErrorAs, &ce)
+	qt.Assert(t, err, qt.ErrorAs, &ce)
+}
+
+// Using errors.Is/errors.As with checkers other than qt.IsTrue/qt.IsFalse is not flagged.
+func TestErrorsIsWithOtherCheckers(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, errors.Is(err, ErrSentinel), qt.Equals, true)
+	c.Assert(errors.Is(err, ErrSentinel), qt.DeepEquals, true)
+}
+
+// User-defined functions named Is/As must not be flagged.
+func TestUserDefinedIsAs(t *testing.T) {
+	c := qt.New(t)
+
+	Is := func(err, target error) bool { return false }
+	As := func(err error, target any) bool { return false }
+
+	err := makeErr()
+	var ce *customErr
+	qt.Assert(t, Is(err, ErrSentinel), qt.IsTrue)
+	c.Assert(As(err, &ce), qt.IsTrue)
+}

--- a/testdata/src/errorisfix/errorisfix.go
+++ b/testdata/src/errorisfix/errorisfix.go
@@ -1,0 +1,57 @@
+package errorisfix
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var ErrSentinel = errors.New("sentinel")
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+func makeErr() error {
+	return ErrSentinel
+}
+
+// Test case: errors.Is(err, target), qt.IsTrue should be replaced with err, qt.ErrorIs, target.
+func TestErrorsIsIsTrue(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, errors.Is(err, ErrSentinel), qt.IsTrue) // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(errors.Is(err, ErrSentinel), qt.IsTrue)     // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+}
+
+// Test case: errors.Is(err, target), qt.IsFalse should be replaced with err, qt.Not(qt.ErrorIs), target.
+func TestErrorsIsIsFalse(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, errors.Is(err, fs.ErrNotExist), qt.IsFalse) // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+	c.Assert(errors.Is(err, fs.ErrNotExist), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: errors.As(err, &target), qt.IsTrue should be replaced with err, qt.ErrorAs, &target.
+func TestErrorsAsIsTrue(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	qt.Assert(t, errors.As(err, &ce), qt.IsTrue) // want "qtlint: use qt.ErrorAs instead of errors.As\\(err, target\\), qt.IsTrue"
+	c.Assert(errors.As(err, &ce), qt.IsTrue)     // want "qtlint: use qt.ErrorAs instead of errors.As\\(err, target\\), qt.IsTrue"
+}
+
+// Test case: errors.As(err, &target), qt.IsFalse should be replaced with err, qt.Not(qt.ErrorAs), &target.
+func TestErrorsAsIsFalse(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	qt.Assert(t, errors.As(err, &ce), qt.IsFalse) // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of errors.As\\(err, target\\), qt.IsFalse"
+	c.Assert(errors.As(err, &ce), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of errors.As\\(err, target\\), qt.IsFalse"
+}

--- a/testdata/src/errorisfix/errorisfix.go.golden
+++ b/testdata/src/errorisfix/errorisfix.go.golden
@@ -1,0 +1,57 @@
+package errorisfix
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var ErrSentinel = errors.New("sentinel")
+
+type customErr struct{ msg string }
+
+func (e *customErr) Error() string { return e.msg }
+
+func makeErr() error {
+	return ErrSentinel
+}
+
+// Test case: errors.Is(err, target), qt.IsTrue should be replaced with err, qt.ErrorIs, target.
+func TestErrorsIsIsTrue(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, err, qt.ErrorIs, ErrSentinel) // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+	c.Assert(err, qt.ErrorIs, ErrSentinel)     // want "qtlint: use qt.ErrorIs instead of errors.Is\\(err, target\\), qt.IsTrue"
+}
+
+// Test case: errors.Is(err, target), qt.IsFalse should be replaced with err, qt.Not(qt.ErrorIs), target.
+func TestErrorsIsIsFalse(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+
+	qt.Assert(t, err, qt.Not(qt.ErrorIs), fs.ErrNotExist) // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+	c.Assert(err, qt.Not(qt.ErrorIs), fs.ErrNotExist)     // want "qtlint: use qt.Not\\(qt.ErrorIs\\) instead of errors.Is\\(err, target\\), qt.IsFalse"
+}
+
+// Test case: errors.As(err, &target), qt.IsTrue should be replaced with err, qt.ErrorAs, &target.
+func TestErrorsAsIsTrue(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	qt.Assert(t, err, qt.ErrorAs, &ce) // want "qtlint: use qt.ErrorAs instead of errors.As\\(err, target\\), qt.IsTrue"
+	c.Assert(err, qt.ErrorAs, &ce)     // want "qtlint: use qt.ErrorAs instead of errors.As\\(err, target\\), qt.IsTrue"
+}
+
+// Test case: errors.As(err, &target), qt.IsFalse should be replaced with err, qt.Not(qt.ErrorAs), &target.
+func TestErrorsAsIsFalse(t *testing.T) {
+	c := qt.New(t)
+	err := makeErr()
+	var ce *customErr
+
+	qt.Assert(t, err, qt.Not(qt.ErrorAs), &ce) // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of errors.As\\(err, target\\), qt.IsFalse"
+	c.Assert(err, qt.Not(qt.ErrorAs), &ce)     // want "qtlint: use qt.Not\\(qt.ErrorAs\\) instead of errors.As\\(err, target\\), qt.IsFalse"
+}

--- a/testdata/src/github.com/frankban/quicktest/quicktest.go
+++ b/testdata/src/github.com/frankban/quicktest/quicktest.go
@@ -51,6 +51,8 @@ var (
 	Equals     Checker
 	DeepEquals Checker
 	HasLen     Checker
+	ErrorIs    Checker
+	ErrorAs    Checker
 )
 
 // Not returns a Checker negating the given Checker.


### PR DESCRIPTION
## Summary

Implements the rule requested in #22: flag the pattern

```go
c.Assert(errors.Is(err, target), qt.IsTrue)
```

and suggest

```go
c.Assert(err, qt.ErrorIs, target)
```

Same treatment is applied to:

- `errors.Is(err, target), qt.IsFalse` → `err, qt.Not(qt.ErrorIs), target`
- `errors.As(err, &target), qt.IsTrue` → `err, qt.ErrorAs, &target`
- `errors.As(err, &target), qt.IsFalse` → `err, qt.Not(qt.ErrorAs), &target`

Each diagnostic ships an `analysis.SuggestedFix`, so `qtlint -fix` (and `golangci-lint run --fix`) rewrites the call sites automatically.

Closes #22.

## Implementation notes

- New `checkErrorIsAsPattern` in `qtlint.go`, invoked from `checkQuicktestCall`. Mirrors the structure of `checkContainsPattern`; matches both `qt.Assert(t, got, checker, …)` and `c.Assert(got, checker, …)` call shapes.
- Resolves the `errors` package via `types.PkgName` so user-defined `Is`/`As` functions and aliased imports (e.g. `myerrors "errors"`) are handled correctly.
- New testdata packages: `erroris`, `errorisfix`, `aliaserrors`, `aliaserrorsfix`. The quicktest stub gains `ErrorIs` / `ErrorAs` checker vars so direct usages in the input compile.
- README updated: the new rule is documented as rule 8 and the existing `if err != nil` rules shift to 9 and 10.

## Test plan

- [x] `go test ./...` — all subtests pass, including the new `errors.Is and errors.As patterns` and `… with package aliases` runs as well as the new fix-test entries.
- [x] `golangci-lint run ./...` — 0 issues.