### PR TITLE
feat: auto-fix `if err != nil { t.Fatal/Error[f] }` with -only-stable-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ qtlint -fix ./...
 
 # Show diff without applying fixes
 qtlint -fix -diff ./...
+
+# Only apply fixes the linter is confident about (skip best-effort rewrites)
+qtlint -fix -only-stable-fixes ./...
 ```
 
 ### With golangci-lint
@@ -111,9 +114,15 @@ Then run with auto-fix:
 golangci-lint run --fix
 ```
 
+### `-only-stable-fixes` flag
+
+Some rewrites have a clear, semantically equivalent target (e.g. `qt.Not(qt.IsNil)` → `qt.IsNotNil`). Others are best-effort: rules 9 and 10 (`if err != nil { t.Fatal/Error[f](...) }`) sometimes synthesize a `qt.Commentf` from arguments that were originally joined by `Sprintln`, or pass through a format string that the linter cannot prove is a string literal. Such rewrites usually do the right thing but may change the failure-message text.
+
+Pass `-only-stable-fixes` to withhold auto-fixes for those uncertain cases. The diagnostic still fires so you can review and apply the change by hand; only the auto-applicable fix is held back. All other rules continue to provide fixes as before.
+
 ## Rules
 
-Most rules support **automatic fixing** with the `-fix` flag. The `if err != nil` rules (9 and 10) report diagnostics only — no automatic fix is provided.
+All rules support **automatic fixing** with the `-fix` flag. For rules 9 and 10 the rewrite is best-effort in some variants (multi-arg `t.Fatal`, non-literal format string, `if`-init statement, spread arguments); the unsafe-by-default variants are still emitted as fixes but can be skipped with `-only-stable-fixes`. Cases that cannot be rewritten at all (init-statement and spread args) remain report-only.
 
 ### 1. Use `qt.IsNotNil` instead of `qt.Not(qt.IsNil)`
 
@@ -344,7 +353,7 @@ c.Assert(err, qt.IsNil)
 c.Assert(err, qt.IsNil, qt.Commentf("unexpected error: %v", err))
 ```
 
-**Auto-fix:** ❌ No automatic fix available
+**Auto-fix:** ✅ for `t.Fatal(err)`, `t.Fatal()`, and `t.Fatalf(literal, …)` with a string-literal format. Best-effort (suppressed by `-only-stable-fixes`) for `t.Fatal("msg:", err, 123)` (multi-arg; format is synthesized as `"%v %v %v"`) and `t.Fatalf(formatVar, …)` (non-literal format). Not provided for `if err := f(); err != nil { t.Fatal(…) }` (init statement would change scoping) or for `t.Fatal(args...)` (spread arguments are opaque).
 
 **Error message:**
 ```
@@ -372,7 +381,7 @@ c.Check(err, qt.IsNil)
 c.Check(err, qt.IsNil, qt.Commentf("unexpected error: %v", err))
 ```
 
-**Auto-fix:** ❌ No automatic fix available
+**Auto-fix:** Same stability matrix as rule 9 (above), targeting `c.Check` instead of `c.Assert`.
 
 **Error message:**
 ```

--- a/qtlint.go
+++ b/qtlint.go
@@ -1306,6 +1306,11 @@ func buildErrNilFatalFix(
 				stable:  true,
 			}, true
 		}
+		// Marked unstable to stay consistent with the multi-arg synthesis below:
+		// both wrap arguments in a synthesized Commentf format and both drop the
+		// trailing newline that Sprintln would have produced. The format is
+		// fixed ("%v") so user-supplied "%" characters in arg pass through
+		// verbatim — there is no format-string injection risk here.
 		return errNilFatalFix{
 			text:    withComment(`"%v", ` + argText),
 			message: fmt.Sprintf("Replace with %s.%s(..., qt.Commentf(\"%%v\", ...))", cVar, m.qtMethod),
@@ -1313,7 +1318,17 @@ func buildErrNilFatalFix(
 		}, true
 	}
 
-	// Multi-arg non-formatted: approximate Sprintln join with "%v %v ..." in Commentf.
+	// Multi-arg non-formatted: approximate Sprintln join with "%v %v ..." in
+	// Commentf.
+	//
+	// Behavioral gap to be aware of: t.Fatal(a, b, c) uses fmt.Sprintln which
+	// joins args with spaces *and appends \n*; qt.Commentf("%v %v %v", a, b, c)
+	// uses fmt.Sprintf which honors the format string and produces no trailing
+	// newline. We do not reproduce the newline because qt.Commentf is lazy —
+	// it's only formatted on assertion failure and most consumers will not
+	// notice the trailing newline either way. This is the canonical reason
+	// this branch's fix is classified unstable: the failure-message text is
+	// nearly but not exactly identical to the original t.Fatal output.
 	argTexts, ok := formatArgs(pass, m.call.Args)
 	if !ok {
 		return errNilFatalFix{}, false

--- a/qtlint.go
+++ b/qtlint.go
@@ -33,6 +33,8 @@ import (
 	"go/format"
 	"go/token"
 	"go/types"
+	"strconv"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -40,17 +42,29 @@ import (
 )
 
 // analyzer is the receiver for analysis pass methods.
-type analyzer struct{}
+type analyzer struct {
+	// onlyStableFixes, when true, strips SuggestedFix from diagnostics whose
+	// rewrite is best-effort and may change runtime semantics or output
+	// formatting (e.g. synthesizing qt.Commentf for a multi-arg t.Fatal whose
+	// args were joined by t.Fatal's Sprintln). The diagnostic is still
+	// reported; only the auto-applicable fix is withheld.
+	onlyStableFixes bool
+}
 
 // NewAnalyzer creates a new instance of the qtlint analyzer.
 func NewAnalyzer() *analysis.Analyzer {
 	a := &analyzer{}
-	return &analysis.Analyzer{
+	aa := &analysis.Analyzer{
 		Name:     "qtlint",
 		Doc:      "enforces best practices for quicktest usage",
 		Run:      a.run,
 		Requires: []*analysis.Analyzer{inspect.Analyzer},
 	}
+	aa.Flags.BoolVar(&a.onlyStableFixes, "only-stable-fixes", false,
+		"emit SuggestedFix only for diagnostics whose rewrite is reliable; "+
+			"best-effort fixes (e.g. errnil-fatal with non-literal format or "+
+			"multi-arg non-formatted call) are reported without an auto-fix")
+	return aa
 }
 
 // Analyzer is the qtlint analyzer that enforces best practices
@@ -1141,7 +1155,7 @@ func errMismatch(pass *analysis.Pass, errExpr ast.Expr, call *ast.CallExpr) bool
 	return false
 }
 
-func (*analyzer) checkErrNilFatalPattern(pass *analysis.Pass, ifStmt *ast.IfStmt) {
+func (a *analyzer) checkErrNilFatalPattern(pass *analysis.Pass, ifStmt *ast.IfStmt) {
 	m, ok := matchErrNilFatal(pass, ifStmt)
 	if !ok {
 		return
@@ -1182,9 +1196,147 @@ func (*analyzer) checkErrNilFatalPattern(pass *analysis.Pass, ifStmt *ast.IfStmt
 		shortAssertText = fmt.Sprintf("%s.%s(%s, %s.IsNil, %s.Commentf(...))", cVar, m.qtMethod, errText, qtAlias, qtAlias)
 	}
 
-	pass.Report(analysis.Diagnostic{
+	diag := analysis.Diagnostic{
 		Pos:     ifStmt.Pos(),
 		End:     ifStmt.End(),
 		Message: fmt.Sprintf("qtlint: use %s instead of %s.%s(...)", shortAssertText, receiverText, m.methodName),
-	})
+	}
+
+	if fix, ok := a.buildErrNilFatalFix(pass, ifStmt, m, cVar, qtAlias, errText); ok {
+		if fix.stable || !a.onlyStableFixes {
+			diag.SuggestedFixes = []analysis.SuggestedFix{{
+				Message: fix.message,
+				TextEdits: []analysis.TextEdit{{
+					Pos:     ifStmt.Pos(),
+					End:     ifStmt.End(),
+					NewText: []byte(fix.text),
+				}},
+			}}
+		}
+	}
+
+	pass.Report(diag)
+}
+
+// errNilFatalFix describes a single-statement rewrite for the
+// `if err != nil { t.Fatal[f]/t.Error[f](...) }` pattern.
+type errNilFatalFix struct {
+	// text is the replacement source for the entire ifStmt span. It is a
+	// single line of code (no indentation prefix, no trailing newline);
+	// the surrounding whitespace in the file is preserved by the TextEdit.
+	text string
+	// message is shown to users in IDE/golangci-lint when offering the fix.
+	message string
+	// stable is true when the rewrite preserves the original call's
+	// semantics exactly (modulo the trailing newline that t.Fatal's Sprintln
+	// added). Unstable fixes synthesize a format string or wrap a
+	// non-error argument and are skipped under -only-stable-fixes.
+	stable bool
+}
+
+// buildErrNilFatalFix returns a rewrite for the if-err-fatal pattern, or
+// ok=false when we cannot safely produce one (init-stmt scoping or spread args).
+func (a *analyzer) buildErrNilFatalFix(
+	pass *analysis.Pass,
+	ifStmt *ast.IfStmt,
+	m errNilFatalMatch,
+	cVar, qtAlias, errText string,
+) (errNilFatalFix, bool) {
+	// `if err := f(); err != nil { ... }` would require pulling the init
+	// statement out, which changes scoping (err leaks into the enclosing
+	// block). Refuse the fix and let the diagnostic stand on its own.
+	if ifStmt.Init != nil {
+		return errNilFatalFix{}, false
+	}
+	// `t.Fatal(args...)` (spread): we cannot enumerate the underlying
+	// arguments at lint time, so any rewrite would silently drop them.
+	if m.call.Ellipsis != token.NoPos {
+		return errNilFatalFix{}, false
+	}
+
+	bare := fmt.Sprintf("%s.%s(%s, %s.IsNil)", cVar, m.qtMethod, errText, qtAlias)
+	withComment := func(commentArgs string) string {
+		return fmt.Sprintf("%s.%s(%s, %s.IsNil, %s.Commentf(%s))",
+			cVar, m.qtMethod, errText, qtAlias, qtAlias, commentArgs)
+	}
+
+	isFmtVariant := m.methodName == "Fatalf" || m.methodName == "Errorf"
+
+	if isFmtVariant {
+		// Fatalf/Errorf require a format argument; defensively refuse if absent.
+		if len(m.call.Args) == 0 {
+			return errNilFatalFix{}, false
+		}
+		argTexts, ok := formatArgs(pass, m.call.Args)
+		if !ok {
+			return errNilFatalFix{}, false
+		}
+		_, formatIsLiteral := m.call.Args[0].(*ast.BasicLit)
+		return errNilFatalFix{
+			text:    withComment(strings.Join(argTexts, ", ")),
+			message: fmt.Sprintf("Replace with %s.%s(..., qt.Commentf(...))", cVar, m.qtMethod),
+			// A literal format string round-trips through fmt.Sprintf inside
+			// Commentf identically. A non-literal could be anything (a const
+			// alias, a function call), so we mark the rewrite unstable.
+			stable: formatIsLiteral,
+		}, true
+	}
+
+	// Non-formatted Fatal/Error: zero args is a clean rewrite to bare assert.
+	if len(m.call.Args) == 0 {
+		return errNilFatalFix{
+			text:    bare,
+			message: fmt.Sprintf("Replace with %s.%s(%s, %s.IsNil)", cVar, m.qtMethod, errText, qtAlias),
+			stable:  true,
+		}, true
+	}
+
+	// Single arg: when it's the same err identifier, drop it entirely (clean).
+	// Otherwise wrap it via qt.Commentf("%v", arg) — semantically close to
+	// t.Fatal's Sprintln output but loses the trailing newline, so unstable.
+	if len(m.call.Args) == 1 {
+		argText, ok := formatExpr(pass, m.call.Args[0])
+		if !ok {
+			return errNilFatalFix{}, false
+		}
+		if argText == errText {
+			return errNilFatalFix{
+				text:    bare,
+				message: fmt.Sprintf("Replace with %s.%s(%s, %s.IsNil)", cVar, m.qtMethod, errText, qtAlias),
+				stable:  true,
+			}, true
+		}
+		return errNilFatalFix{
+			text:    withComment(`"%v", ` + argText),
+			message: fmt.Sprintf("Replace with %s.%s(..., qt.Commentf(\"%%v\", ...))", cVar, m.qtMethod),
+			stable:  false,
+		}, true
+	}
+
+	// Multi-arg non-formatted: approximate Sprintln join with "%v %v ..." in Commentf.
+	argTexts, ok := formatArgs(pass, m.call.Args)
+	if !ok {
+		return errNilFatalFix{}, false
+	}
+	placeholders := strings.TrimRight(strings.Repeat("%v ", len(m.call.Args)), " ")
+	commentArgs := strconv.Quote(placeholders) + ", " + strings.Join(argTexts, ", ")
+	return errNilFatalFix{
+		text:    withComment(commentArgs),
+		message: fmt.Sprintf("Replace with %s.%s(..., qt.Commentf(\"%%v ...\", ...))", cVar, m.qtMethod),
+		stable:  false,
+	}, true
+}
+
+// formatArgs formats a slice of AST expressions, returning ok=false if any
+// expression cannot be rendered (e.g. token positions out of range).
+func formatArgs(pass *analysis.Pass, exprs []ast.Expr) ([]string, bool) {
+	out := make([]string, 0, len(exprs))
+	for _, e := range exprs {
+		s, ok := formatExpr(pass, e)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, s)
+	}
+	return out, true
 }

--- a/qtlint.go
+++ b/qtlint.go
@@ -1202,7 +1202,7 @@ func (a *analyzer) checkErrNilFatalPattern(pass *analysis.Pass, ifStmt *ast.IfSt
 		Message: fmt.Sprintf("qtlint: use %s instead of %s.%s(...)", shortAssertText, receiverText, m.methodName),
 	}
 
-	if fix, ok := a.buildErrNilFatalFix(pass, ifStmt, m, cVar, qtAlias, errText); ok {
+	if fix, ok := buildErrNilFatalFix(pass, ifStmt, m, cVar, qtAlias, errText); ok {
 		if fix.stable || !a.onlyStableFixes {
 			diag.SuggestedFixes = []analysis.SuggestedFix{{
 				Message: fix.message,
@@ -1236,7 +1236,7 @@ type errNilFatalFix struct {
 
 // buildErrNilFatalFix returns a rewrite for the if-err-fatal pattern, or
 // ok=false when we cannot safely produce one (init-stmt scoping or spread args).
-func (a *analyzer) buildErrNilFatalFix(
+func buildErrNilFatalFix(
 	pass *analysis.Pass,
 	ifStmt *ast.IfStmt,
 	m errNilFatalMatch,

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -18,4 +18,19 @@ func TestFixes(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "aliascontainsfix")
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "errorisfix")
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "aliaserrorsfix")
+
+	// Default behavior: stable AND unstable errnil-fatal fixes apply.
+	t.Run("errcheckfix default applies all", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "errcheckfix")
+	})
+
+	// With --only-stable-fixes: unstable fixes are withheld; diagnostics still fire.
+	t.Run("errcheckfix only-stable-fixes", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		if err := analyzer.Flags.Set("only-stable-fixes", "true"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "errcheckonlystable")
+	})
 }

--- a/testdata/src/errcheckfix/errcheckfix.go
+++ b/testdata/src/errcheckfix/errcheckfix.go
@@ -35,6 +35,18 @@ func TestStableError(t *testing.T) {
 	c.Assert(1, qt.Equals, 1)
 }
 
+// Stable: zero-arg Fatal collapses to a bare c.Assert.
+func TestStableFatalNoArgs(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal()
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
 // Stable: Fatalf with a literal format string maps directly to qt.Commentf.
 func TestStableFatalfLiteral(t *testing.T) {
 	c := qt.New(t)

--- a/testdata/src/errcheckfix/errcheckfix.go
+++ b/testdata/src/errcheckfix/errcheckfix.go
@@ -1,0 +1,124 @@
+package errcheckfix
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func returnsErr() error {
+	return errors.New("boom")
+}
+
+// Stable: single-err Fatal collapses to a bare c.Assert.
+func TestStableFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal(err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: single-err Error collapses to a bare c.Check.
+func TestStableError(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Check.*instead of t.Error"
+		t.Error(err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: Fatalf with a literal format string maps directly to qt.Commentf.
+func TestStableFatalfLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: Errorf with a literal format string maps directly to qt.Commentf.
+func TestStableErrorfLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Check.*instead of t.Errorf"
+		t.Errorf("unexpected: %v", err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable: multi-arg non-formatted Fatal — Sprintln output is approximated
+// by a synthesized "%v %v %v" format.
+func TestUnstableMultiArgFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal("unexpected:", err, 123)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable: single non-err arg is wrapped via qt.Commentf("%v", ...).
+func TestUnstableSingleNonErrArg(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Check.*instead of t.Error"
+		t.Error("standalone message")
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable: format string is a variable — we cannot tell at lint time
+// whether it round-trips identically through qt.Commentf.
+func TestUnstableNonLiteralFormat(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	fmtStr := "got: %v"
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf(fmtStr, err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// No fix: pulling the init statement out would change scoping. The diagnostic
+// still fires so the user knows about the pattern.
+func TestNoFixInitStmt(t *testing.T) {
+	c := qt.New(t)
+
+	if err := returnsErr(); err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal(err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// No fix: spread args are opaque — we cannot enumerate the underlying values.
+func TestNoFixSpread(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	args := []any{err, 123}
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf("got: %v %v", args...)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}

--- a/testdata/src/errcheckfix/errcheckfix.go.golden
+++ b/testdata/src/errcheckfix/errcheckfix.go.golden
@@ -31,6 +31,16 @@ func TestStableError(t *testing.T) {
 	c.Assert(1, qt.Equals, 1)
 }
 
+// Stable: zero-arg Fatal collapses to a bare c.Assert.
+func TestStableFatalNoArgs(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(1, qt.Equals, 1)
+}
+
 // Stable: Fatalf with a literal format string maps directly to qt.Commentf.
 func TestStableFatalfLiteral(t *testing.T) {
 	c := qt.New(t)

--- a/testdata/src/errcheckfix/errcheckfix.go.golden
+++ b/testdata/src/errcheckfix/errcheckfix.go.golden
@@ -1,0 +1,110 @@
+package errcheckfix
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func returnsErr() error {
+	return errors.New("boom")
+}
+
+// Stable: single-err Fatal collapses to a bare c.Assert.
+func TestStableFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: single-err Error collapses to a bare c.Check.
+func TestStableError(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Check(err, qt.IsNil)
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: Fatalf with a literal format string maps directly to qt.Commentf.
+func TestStableFatalfLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Assert(err, qt.IsNil, qt.Commentf("unexpected: %v", err))
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: Errorf with a literal format string maps directly to qt.Commentf.
+func TestStableErrorfLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Check(err, qt.IsNil, qt.Commentf("unexpected: %v", err))
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable: multi-arg non-formatted Fatal — Sprintln output is approximated
+// by a synthesized "%v %v %v" format.
+func TestUnstableMultiArgFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Assert(err, qt.IsNil, qt.Commentf("%v %v %v", "unexpected:", err, 123))
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable: single non-err arg is wrapped via qt.Commentf("%v", ...).
+func TestUnstableSingleNonErrArg(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Check(err, qt.IsNil, qt.Commentf("%v", "standalone message"))
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable: format string is a variable — we cannot tell at lint time
+// whether it round-trips identically through qt.Commentf.
+func TestUnstableNonLiteralFormat(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	fmtStr := "got: %v"
+	c.Assert(err, qt.IsNil, qt.Commentf(fmtStr, err))
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// No fix: pulling the init statement out would change scoping. The diagnostic
+// still fires so the user knows about the pattern.
+func TestNoFixInitStmt(t *testing.T) {
+	c := qt.New(t)
+
+	if err := returnsErr(); err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal(err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// No fix: spread args are opaque — we cannot enumerate the underlying values.
+func TestNoFixSpread(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	args := []any{err, 123}
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf("got: %v %v", args...)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}

--- a/testdata/src/errcheckonlystable/errcheckonlystable.go
+++ b/testdata/src/errcheckonlystable/errcheckonlystable.go
@@ -1,0 +1,61 @@
+package errcheckonlystable
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func returnsErr() error {
+	return errors.New("boom")
+}
+
+// Stable: single-err Fatal collapses to a bare c.Assert.
+func TestStableFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal(err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: Fatalf with a literal format string maps directly to qt.Commentf.
+func TestStableFatalfLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf("unexpected: %v", err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable (suppressed under --only-stable-fixes): multi-arg non-formatted.
+func TestUnstableMultiArgFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal("unexpected:", err, 123)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable (suppressed under --only-stable-fixes): non-literal format.
+func TestUnstableNonLiteralFormat(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	fmtStr := "got: %v"
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf(fmtStr, err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}

--- a/testdata/src/errcheckonlystable/errcheckonlystable.go.golden
+++ b/testdata/src/errcheckonlystable/errcheckonlystable.go.golden
@@ -1,0 +1,57 @@
+package errcheckonlystable
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func returnsErr() error {
+	return errors.New("boom")
+}
+
+// Stable: single-err Fatal collapses to a bare c.Assert.
+func TestStableFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Stable: Fatalf with a literal format string maps directly to qt.Commentf.
+func TestStableFatalfLiteral(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	c.Assert(err, qt.IsNil, qt.Commentf("unexpected: %v", err))
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable (suppressed under --only-stable-fixes): multi-arg non-formatted.
+func TestUnstableMultiArgFatal(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatal"
+		t.Fatal("unexpected:", err, 123)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}
+
+// Unstable (suppressed under --only-stable-fixes): non-literal format.
+func TestUnstableNonLiteralFormat(t *testing.T) {
+	c := qt.New(t)
+
+	err := returnsErr()
+	fmtStr := "got: %v"
+	if err != nil { // want "qtlint: use c.Assert.*instead of t.Fatalf"
+		t.Fatalf(fmtStr, err)
+	}
+
+	c.Assert(1, qt.Equals, 1)
+}


### PR DESCRIPTION
## Summary

Rules 9 and 10 — `if err != nil { t.Fatal[f](...) }` and `if err != nil { t.Error[f](...) }` — previously reported diagnostics only. Their rewrite into `c.Assert/Check(err, qt.IsNil[, qt.Commentf(...)])` is not always semantically equivalent (`t.Fatal`'s `Sprintln` join can only be approximated through a synthesized `Commentf` format string), so attaching a SuggestedFix unconditionally would be risky for code that depends on the exact failure-message text.

This PR provides auto-fixes for those rules and introduces a new analyzer flag `-only-stable-fixes` that suppresses the best-effort variants when the user wants `-fix` to be conservative.

### Classification

| Pattern | Type | Rewrite |
|---|---|---|
| `t.Fatal(err)` / `t.Error(err)` (single arg == the if's err) | **stable** | `c.Assert/Check(err, qt.IsNil)` |
| `t.Fatal()` / `t.Error()` (no args) | **stable** | `c.Assert/Check(err, qt.IsNil)` |
| `t.Fatalf("literal", args...)` / `Errorf` with a literal format | **stable** | `c.Assert/Check(err, qt.IsNil, qt.Commentf("literal", args...))` |
| `t.Fatal("msg:", err, 123)` (multi-arg non-formatted) | **unstable** | synthesizes `qt.Commentf("%v %v %v", "msg:", err, 123)` approximating `Sprintln` |
| `t.Fatal("standalone")` (single non-err arg) | **unstable** | wraps via `qt.Commentf("%v", "standalone")` |
| `t.Fatalf(formatVar, err)` (non-literal format) | **unstable** | direct pass-through; format identity not provable at lint time |
| `if err := f(); err != nil { … }` (init statement) | **no fix** | rewrite would change scoping; diagnostic only |
| `t.Fatal(args...)` (spread) | **no fix** | argument list is opaque; diagnostic only |

Under `-only-stable-fixes`, the unstable variants still produce a diagnostic — only the auto-applicable fix is withheld. The flag is registered on `Analyzer.Flags`, so the standalone CLI (`qtlint -fix -only-stable-fixes ./...`) and golangci-lint settings pick it up automatically.

### Changes

- `qtlint.go` — extend `*analyzer` with `onlyStableFixes`; register the `-only-stable-fixes` flag; build a `SuggestedFix` in `checkErrNilFatalPattern` via the new `buildErrNilFatalFix` helper (with stability classification).
- `qtlint_fix_test.go` — two new subtests, one per flag state, using fresh `NewAnalyzer()` instances.
- `testdata/src/errcheckfix/` — full coverage (stable + unstable + no-fix cases), golden shows every rewritable case applied (default flag state).
- `testdata/src/errcheckonlystable/` — same shape but golden leaves unstable cases untouched (flag enabled).
- `README.md` — rule 9/10 stability matrix and a section documenting the new flag.

## Test plan

- [x] `go test ./...` passes (full suite, including the two new subtests).
- [x] `go vet ./...` clean.
- [x] `gofmt -l` on touched files — no diffs.
- [x] `go build ./cmd/qtlint && ./qtlint -h` lists `-only-stable-fixes`.
- [ ] Reviewer: sanity-check that the unstable `t.Fatal("msg:", err, 123)` → `qt.Commentf("%v %v %v", …)` synthesis matches your taste; flip to "no fix" if you'd rather not ship that variant even behind the flag.