### PR TITLE
feat: detect qt.Equals with nil literal and suggest qt.IsNil (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The tool helps enforce best practices for quicktest usage by detecting suboptima
 - Detecting `errors.As(err, &target), qt.IsFalse` and suggesting `err, qt.Not(qt.ErrorAs), &target`
 - Detecting `if err != nil { t.Fatal[f](...) }` and suggesting `c.Assert(err, qt.IsNil, qt.Commentf(...))`
 - Detecting `if err != nil { t.Error[f](...) }` and suggesting `c.Check(err, qt.IsNil, qt.Commentf(...))`
+- Detecting `x, qt.Equals, nil` and suggesting `x, qt.IsNil`
 
 This ensures that tests use the most direct and readable checker available.
 
@@ -387,6 +388,29 @@ c.Check(err, qt.IsNil, qt.Commentf("unexpected error: %v", err))
 ```
 qtlint: use c.Check(err, qt.IsNil) instead of t.Error(...)
 qtlint: use c.Check(err, qt.IsNil, qt.Commentf(...)) instead of t.Errorf(...)
+```
+
+### 11. Use `qt.IsNil` instead of `qt.Equals, nil`
+
+The quicktest `Equals` checker compares `got` and `want` with `==`. A typed nil (e.g. `(*T)(nil)`) never equals the untyped `nil` literal, so `c.Assert((*T)(nil), qt.Equals, nil)` fails at runtime; only an untyped nil interface happens to pass. quicktest's own documentation recommends `qt.IsNil` for nil checks.
+
+**Bad:**
+```go
+c.Assert(x, qt.Equals, nil)
+qt.Assert(t, x, qt.Equals, nil)
+```
+
+**Good:**
+```go
+c.Assert(x, qt.IsNil)
+qt.Assert(t, x, qt.IsNil)
+```
+
+**Auto-fix:** ✅ Automatically replaces `qt.Equals, nil` with `qt.IsNil`, dropping the `want` argument. Trailing arguments such as `qt.Commentf(...)` are preserved.
+
+**Error message:**
+```
+qtlint: use qt.IsNil instead of qt.Equals, nil
 ```
 
 ## Examples

--- a/qtlint.go
+++ b/qtlint.go
@@ -22,6 +22,7 @@
 //   - errors.As(err, &target), qt.IsFalse which should be replaced with err, qt.Not(qt.ErrorAs), &target
 //   - if err != nil { t.Fatal[f](...) } which should be replaced with c.Assert(err, qt.IsNil, qt.Commentf(...))
 //   - if err != nil { t.Error[f](...) } which should be replaced with c.Check(err, qt.IsNil, qt.Commentf(...))
+//   - x, qt.Equals, nil which should be replaced with x, qt.IsNil
 //
 // This linter is designed to be used as a custom linter for golangci-lint.
 package qtlint
@@ -135,6 +136,80 @@ func checkQuicktestCall(pass *analysis.Pass, call *ast.CallExpr) {
 
 	// Check for errors.Is(err, target) or errors.As(err, &target) with qt.IsTrue/qt.IsFalse pattern.
 	checkErrorIsAsPattern(pass, call)
+
+	// Check for x, qt.Equals, nil pattern.
+	checkEqualsNilPattern(pass, call)
+}
+
+// checkEqualsNilPattern checks if the pattern is x, qt.Equals, nil and suggests
+// using x, qt.IsNil instead. The quicktest Equals checker compares got and want
+// with ==, so a typed nil (e.g. (*T)(nil)) never equals the untyped nil literal;
+// only an untyped nil interface happens to pass. The qt.IsNil checker is the
+// correct way to check for nil, as documented by quicktest itself.
+func checkEqualsNilPattern(pass *analysis.Pass, call *ast.CallExpr) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return
+	}
+
+	// Determine the position of the "got" argument based on whether it's
+	// qt.Assert(t, got, checker, want, ...) or c.Assert(got, checker, want, ...).
+	gotArgIndex := 0
+	if isPackageQualified(pass, sel) {
+		gotArgIndex = 1
+	}
+
+	checkerIndex := gotArgIndex + 1
+	wantIndex := gotArgIndex + 2
+
+	// Need at least got, checker, and want arguments.
+	if len(call.Args) < wantIndex+1 {
+		return
+	}
+
+	checkerArg := call.Args[checkerIndex]
+	wantArg := call.Args[wantIndex]
+
+	// The checker must be qt.Equals.
+	checkerSel, ok := checkerArg.(*ast.SelectorExpr)
+	if !ok || checkerSel.Sel.Name != "Equals" {
+		return
+	}
+	if !isPackageQualified(pass, checkerSel) {
+		return
+	}
+
+	// The want argument must be the nil identifier.
+	if !isNilIdent(wantArg) {
+		return
+	}
+
+	pkgIdent, ok := checkerSel.X.(*ast.Ident)
+	if !ok {
+		return
+	}
+
+	// Replace the "qt.Equals, nil" span with "qt.IsNil", dropping the want
+	// argument. Any trailing arguments (e.g. qt.Commentf(...)) are preserved.
+	newText := pkgIdent.Name + ".IsNil"
+
+	pass.Report(analysis.Diagnostic{
+		Pos:     checkerArg.Pos(),
+		End:     wantArg.End(),
+		Message: "qtlint: use qt.IsNil instead of qt.Equals, nil",
+		SuggestedFixes: []analysis.SuggestedFix{
+			{
+				Message: "Replace with qt.IsNil",
+				TextEdits: []analysis.TextEdit{
+					{
+						Pos:     checkerArg.Pos(),
+						End:     wantArg.End(),
+						NewText: []byte(newText),
+					},
+				},
+			},
+		},
+	})
 }
 
 // getCheckerArg extracts the checker argument from a quicktest assertion call.

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -18,6 +18,7 @@ func TestFixes(t *testing.T) {
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "aliascontainsfix")
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "errorisfix")
 	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "aliaserrorsfix")
+	analysistest.RunWithSuggestedFixes(t, testdata, qtlint.Analyzer, "equalsnilfix")
 
 	// Default behavior: stable AND unstable errnil-fatal fixes apply.
 	t.Run("errcheckfix default applies all", func(t *testing.T) {

--- a/qtlint_test.go
+++ b/qtlint_test.go
@@ -65,4 +65,9 @@ func TestAnalyzer(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		analysistest.Run(t, testdata, analyzer, "aliaserrors")
 	})
+
+	t.Run("qt.Equals with nil patterns", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		analysistest.Run(t, testdata, analyzer, "equalsnil")
+	})
 }

--- a/testdata/src/equalsnil/equalsnil.go
+++ b/testdata/src/equalsnil/equalsnil.go
@@ -1,0 +1,72 @@
+package equalsnil
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+type sometype struct{}
+
+// Test case: x, qt.Equals, nil should be replaced with x, qt.IsNil.
+func TestEqualsNilAssert(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+
+	qt.Assert(t, x, qt.Equals, nil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Assert(x, qt.Equals, nil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+}
+
+// Test case: qt.Check should also be checked.
+func TestEqualsNilCheck(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+
+	qt.Check(t, x, qt.Equals, nil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Check(x, qt.Equals, nil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+}
+
+// Test case: a typed nil is exactly the buggy comparison quicktest warns about.
+func TestEqualsTypedNil(t *testing.T) {
+	c := qt.New(t)
+
+	qt.Assert(t, (*sometype)(nil), qt.Equals, nil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Assert((*sometype)(nil), qt.Equals, nil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+}
+
+// Test case: trailing arguments (e.g. qt.Commentf) are preserved.
+func TestEqualsNilWithComment(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+
+	c.Assert(x, qt.Equals, nil, qt.Commentf("should be nil")) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+}
+
+// Negative test cases: patterns that should NOT trigger the rule.
+
+// Using qt.IsNil directly is correct.
+func TestIsNilDirect(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+
+	qt.Assert(t, x, qt.IsNil)
+	c.Assert(x, qt.IsNil)
+}
+
+// qt.Equals with a non-nil want is fine.
+func TestEqualsNonNil(t *testing.T) {
+	c := qt.New(t)
+	x := 42
+
+	qt.Assert(t, x, qt.Equals, 42)
+	c.Assert(x, qt.Equals, 42)
+}
+
+// A different checker with nil is not flagged by this rule.
+func TestDeepEqualsNil(t *testing.T) {
+	c := qt.New(t)
+	var x []int
+
+	qt.Assert(t, x, qt.DeepEquals, nil)
+	c.Assert(x, qt.DeepEquals, nil)
+}

--- a/testdata/src/equalsnilfix/equalsnilfix.go
+++ b/testdata/src/equalsnilfix/equalsnilfix.go
@@ -1,0 +1,25 @@
+package equalsnilfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+type sometype struct{}
+
+func TestEqualsNilFix(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+
+	qt.Assert(t, x, qt.Equals, nil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Assert(x, qt.Equals, nil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+
+	qt.Check(t, x, qt.Equals, nil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Check(x, qt.Equals, nil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+
+	qt.Assert(t, (*sometype)(nil), qt.Equals, nil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Assert((*sometype)(nil), qt.Equals, nil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+
+	c.Assert(x, qt.Equals, nil, qt.Commentf("should be nil")) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+}

--- a/testdata/src/equalsnilfix/equalsnilfix.go.golden
+++ b/testdata/src/equalsnilfix/equalsnilfix.go.golden
@@ -1,0 +1,25 @@
+package equalsnilfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+type sometype struct{}
+
+func TestEqualsNilFix(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+
+	qt.Assert(t, x, qt.IsNil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Assert(x, qt.IsNil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+
+	qt.Check(t, x, qt.IsNil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Check(x, qt.IsNil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+
+	qt.Assert(t, (*sometype)(nil), qt.IsNil) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+	c.Assert((*sometype)(nil), qt.IsNil)     // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+
+	c.Assert(x, qt.IsNil, qt.Commentf("should be nil")) // want "qtlint: use qt.IsNil instead of qt.Equals, nil"
+}

--- a/testdata/src/github.com/frankban/quicktest/quicktest.go
+++ b/testdata/src/github.com/frankban/quicktest/quicktest.go
@@ -59,3 +59,11 @@ var (
 func Not(checker Checker) Checker {
 	return nil
 }
+
+// Comment is a comment associated with an assertion.
+type Comment struct{}
+
+// Commentf returns a Comment with the given formatted message.
+func Commentf(format string, args ...interface{}) Comment {
+	return Comment{}
+}


### PR DESCRIPTION
## Summary

Implements #26. Adds a new qtlint rule that detects `x, qt.Equals, nil` and suggests `x, qt.IsNil`.

The quicktest `Equals` checker compares `got` and `want` with `==`, so a typed nil such as `(*T)(nil)` never equals the untyped `nil` literal at runtime; only an untyped nil interface happens to pass. quicktest's own docs recommend `qt.IsNil` for nil checks.

| Found | Suggested |
|-------|-----------|
| `x, qt.Equals, nil` | `x, qt.IsNil` |

## Changes

- **`qtlint.go`** — new `checkEqualsNilPattern`, wired into `checkQuicktestCall`. Resolves the got-arg offset via `isPackageQualified` (1 for `qt.Assert`, 0 for `c.Assert`), verifies the checker is `qt.Equals` and the want arg is the `nil` identifier, then reports a diagnostic. The auto-fix replaces the `qt.Equals, nil` span with `qt.IsNil`, dropping the want argument while preserving any trailing args (e.g. `qt.Commentf(...)`).
- **Tests** — detection cases in `testdata/src/equalsnil` (Assert/Check, both layouts, typed-nil `(*sometype)(nil)`, trailing `Commentf`, plus negatives) and suggested-fix golden in `testdata/src/equalsnilfix`; both registered in `qtlint_test.go` / `qtlint_fix_test.go`. Added a `Commentf`/`Comment` stub to the quicktest test package so testdata using a trailing comment arg typechecks under `analysistest`.
- **`README.md`** — feature-list entry and new "Rule 11" section.

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (new `equalsnil` + `equalsnilfix` subtests pass)
- `golangci-lint run ./...` → 0 issues

Closes #26