### PR TITLE
feat: add opt-in -require-qt-c-receiver rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The tool helps enforce best practices for quicktest usage by detecting suboptima
 
 This ensures that tests use the most direct and readable checker available.
 
+A second, smaller group of rules is **opt-in and off by default**. They choose between two forms that are both correct quicktest, so whether a project wants them enforced is a house-style decision rather than a correctness one:
+
+- `-require-qt-c-receiver`: detecting `qt.Assert(t, …)` / `qt.Check(t, …)` and suggesting `c.Assert(…)` / `c.Check(…)` on a `*qt.C`
+
+Nothing in the default rule set changes when these flags are absent.
+
 ## Installation
 
 ### As a golangci-lint plugin
@@ -97,6 +103,10 @@ qtlint -fix -diff ./...
 
 # Only apply fixes the linter is confident about (skip best-effort rewrites)
 qtlint -fix -only-stable-fixes ./...
+
+# Enable an opt-in house-style rule (off unless asked for)
+qtlint -require-qt-c-receiver ./...
+qtlint -fix -require-qt-c-receiver ./...
 ```
 
 ### With golangci-lint
@@ -122,6 +132,8 @@ Some rewrites have a clear, semantically equivalent target (e.g. `qt.Not(qt.IsNi
 Pass `-only-stable-fixes` to withhold auto-fixes for those uncertain cases. The diagnostic still fires so you can review and apply the change by hand; only the auto-applicable fix is held back. All other rules continue to provide fixes as before.
 
 ## Rules
+
+Rules 1 to 11 are on by default. Rule 12 and above are **house-style rules, off by default**, and each is named after the flag that turns it on.
 
 All rules support **automatic fixing** with the `-fix` flag. For rules 9 and 10 the rewrite is best-effort in some variants (multi-arg `t.Fatal`, non-literal format string, `if`-init statement, spread arguments); the unsafe-by-default variants are still emitted as fixes but can be skipped with `-only-stable-fixes`. Cases that cannot be rewritten at all (init-statement and spread args) remain report-only.
 
@@ -411,6 +423,42 @@ qt.Assert(t, x, qt.IsNil)
 **Error message:**
 ```
 qtlint: use qt.IsNil instead of qt.Equals, nil
+```
+
+### 12. Require assertions to go through a `*qt.C` receiver — `-require-qt-c-receiver`
+
+**House-style rule, off by default.** quicktest exposes both a package-level assertion taking a `testing.TB` and a method on `*qt.C`, and both are correct. Some projects require the second form everywhere, so that a test function has exactly one `*qt.C` and every assertion goes through it: the `*qt.C` is what carries `c.Cleanup`, `c.Setenv`, `c.TempDir`, `c.Patch`, `c.Defer` and `c.Parallel`, as well as any comment state the test attached to it, and a file that mixes both forms grows two ways of reaching the test's context. Pass `-require-qt-c-receiver` to enforce it; without the flag nothing below is reported.
+
+**Bad:**
+```go
+func TestExample(t *testing.T) {
+    qt.Assert(t, got, qt.Equals, want)
+    qt.Check(t, err, qt.IsNil)
+}
+```
+
+**Good:**
+```go
+func TestExample(t *testing.T) {
+    c := qt.New(t)
+    c.Assert(got, qt.Equals, want)
+    c.Check(err, qt.IsNil)
+}
+```
+
+**Auto-fix:** ✅ for every reported call, and `-only-stable-fixes` withholds none of them — creating a `*qt.C` from a `*testing.T` cannot change what the test does. The fix reuses a `*qt.C` that was created from the same `*testing.T` when one is visible under its own name at the call site, and otherwise inserts `c := qt.New(t)` as the first statement of the function that *binds* that `*testing.T` — the subtest closure rather than the parent test when the assertion sits inside one, and the helper's own body when the assertion sits in a helper taking `t *testing.T`. When the name `c` is already taken in that function, the next free name (`c2`, `c3`, …) is used rather than declining the fix.
+
+The rule does not fire when:
+
+- the first argument is not an identifier of type `*testing.T` — `qt.Assert` accepts any `testing.TB`, and a `*testing.B`, a bare `testing.TB` or a field selector such as `h.t` is left alone;
+- no function on the enclosing stack binds that identifier as a parameter, so there is nowhere to put the `qt.New` call.
+
+An aliased quicktest import is matched the same way the default rules match it — through the type checker, not the identifier — and the fix writes whichever alias the file uses.
+
+**Error message:**
+```
+qtlint: use c.Assert(...) instead of qt.Assert(t, ...)
+qtlint: use c.Check(...) instead of qt.Check(t, ...)
 ```
 
 ## Examples

--- a/qtcbinding.go
+++ b/qtcbinding.go
@@ -1,0 +1,176 @@
+package qtlint
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// testingPkgPath is the import path of the standard library testing package.
+const testingPkgPath = "testing"
+
+// isTestingTPtr reports whether typ is exactly *testing.T.
+//
+// The opt-in rules that rewrite between a *testing.T and a *qt.C insist on
+// this exact type rather than on testing.TB: qt.New accepts any testing.TB,
+// but only a *testing.T can stand where the rewrite puts one.
+func isTestingTPtr(typ types.Type) bool {
+	ptr, ok := types.Unalias(typ).(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(ptr.Elem()).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == testingPkgPath && obj.Name() == "T"
+}
+
+// identNamesIn collects every identifier name that appears anywhere within n.
+//
+// It is deliberately coarse: a name used as a struct field or a label is
+// reported as taken even though it would not actually collide. Declining a
+// name we could have used costs a suffix digit; using one we could not costs
+// a rewrite that does not compile.
+func identNamesIn(n ast.Node) map[string]bool {
+	names := make(map[string]bool)
+	ast.Inspect(n, func(node ast.Node) bool {
+		if id, ok := node.(*ast.Ident); ok {
+			names[id.Name] = true
+		}
+		return true
+	})
+	return names
+}
+
+// freeName returns base when it does not appear in taken, and otherwise the
+// first of base2, base3, … that does not.
+func freeName(base string, taken map[string]bool) string {
+	if !taken[base] {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := base + strconv.Itoa(i)
+		if !taken[candidate] {
+			return candidate
+		}
+	}
+}
+
+// collectQtCOrigins maps every *qt.C variable declared within root by a call
+// to qt.New to the argument of that call.
+//
+// Only c := qt.New(t) and var c = qt.New(t) are recognized. A *qt.C obtained
+// any other way (a parameter, a struct field, a helper's return value) has no
+// statically known testing.TB behind it, which is why the rules below decline
+// to reason about it.
+func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.Expr {
+	origins := make(map[types.Object]ast.Expr)
+
+	record := func(name, value ast.Expr) {
+		ident, ok := name.(*ast.Ident)
+		if !ok {
+			return
+		}
+		obj := pass.TypesInfo.Defs[ident]
+		if obj == nil || !isQuicktestCType(obj.Type()) {
+			return
+		}
+		if arg, ok := qtNewArg(pass, value); ok {
+			origins[obj] = arg
+		}
+	}
+
+	ast.Inspect(root, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			if stmt.Tok == token.DEFINE && len(stmt.Lhs) == 1 && len(stmt.Rhs) == 1 {
+				record(stmt.Lhs[0], stmt.Rhs[0])
+			}
+		case *ast.DeclStmt:
+			collectQtCVarSpecs(stmt, record)
+		}
+		return true
+	})
+
+	return origins
+}
+
+// collectQtCVarSpecs feeds every single-name, single-value var specification
+// in stmt to record.
+func collectQtCVarSpecs(stmt *ast.DeclStmt, record func(name, value ast.Expr)) {
+	decl, ok := stmt.Decl.(*ast.GenDecl)
+	if !ok || decl.Tok != token.VAR {
+		return
+	}
+	for _, spec := range decl.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+			continue
+		}
+		record(vs.Names[0], vs.Values[0])
+	}
+}
+
+// qtNewArg returns the sole argument of a call to quicktest's New function.
+func qtNewArg(pass *analysis.Pass, expr ast.Expr) (ast.Expr, bool) {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return nil, false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "New" || !isPackageQualified(pass, sel) {
+		return nil, false
+	}
+	if len(call.Args) != 1 {
+		return nil, false
+	}
+	return call.Args[0], true
+}
+
+// funcBindsObject reports whether params declares obj.
+func funcBindsObject(pass *analysis.Pass, params *ast.FieldList, obj types.Object) bool {
+	if params == nil {
+		return false
+	}
+	for _, field := range params.List {
+		for _, name := range field.Names {
+			if pass.TypesInfo.Defs[name] == obj {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// enclosingBindingBody returns the body of the innermost function on stack
+// whose parameter list declares obj, or nil when no function on the stack
+// does.
+func enclosingBindingBody(pass *analysis.Pass, stack []ast.Node, obj types.Object) *ast.BlockStmt {
+	for i := len(stack) - 1; i >= 0; i-- {
+		switch fn := stack[i].(type) {
+		case *ast.FuncDecl:
+			if funcBindsObject(pass, fn.Type.Params, obj) {
+				return fn.Body
+			}
+		case *ast.FuncLit:
+			if funcBindsObject(pass, fn.Type.Params, obj) {
+				return fn.Body
+			}
+		}
+	}
+	return nil
+}
+
+// prependStmtEdit returns the edit that makes code the first statement of
+// body. The inserted text carries no indentation: every driver that applies a
+// SuggestedFix reformats the file afterwards.
+func prependStmtEdit(body *ast.BlockStmt, code string) analysis.TextEdit {
+	at := body.Lbrace + 1
+	return analysis.TextEdit{Pos: at, End: at, NewText: []byte("\n" + code)}
+}

--- a/qtlint.go
+++ b/qtlint.go
@@ -24,6 +24,11 @@
 //   - if err != nil { t.Error[f](...) } which should be replaced with c.Check(err, qt.IsNil, qt.Commentf(...))
 //   - x, qt.Equals, nil which should be replaced with x, qt.IsNil
 //
+// It also carries house-style rules that are off unless their flag is set,
+// because both forms they choose between are correct quicktest:
+//   - -require-qt-c-receiver: qt.Assert(t, ...) / qt.Check(t, ...) which
+//     should be replaced with c.Assert(...) / c.Check(...) on a *qt.C
+//
 // This linter is designed to be used as a custom linter for golangci-lint.
 package qtlint
 
@@ -50,6 +55,12 @@ type analyzer struct {
 	// args were joined by t.Fatal's Sprintln). The diagnostic is still
 	// reported; only the auto-applicable fix is withheld.
 	onlyStableFixes bool
+
+	// requireQtCReceiver enables the opt-in house-style rule that requires
+	// assertions to go through a *qt.C receiver rather than the package-level
+	// qt.Assert(t, …) / qt.Check(t, …) form. It is off by default: both forms
+	// are correct quicktest, and which one a project wants is a style choice.
+	requireQtCReceiver bool
 }
 
 // NewAnalyzer creates a new instance of the qtlint analyzer.
@@ -65,6 +76,9 @@ func NewAnalyzer() *analysis.Analyzer {
 		"emit SuggestedFix only for diagnostics whose rewrite is reliable; "+
 			"best-effort fixes (e.g. errnil-fatal with non-literal format or "+
 			"multi-arg non-formatted call) are reported without an auto-fix")
+	aa.Flags.BoolVar(&a.requireQtCReceiver, "require-qt-c-receiver", false,
+		"house-style rule, off by default: report qt.Assert(t, ...) and "+
+			"qt.Check(t, ...) and suggest the *qt.C method form")
 	return aa
 }
 
@@ -101,7 +115,39 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		}
 	})
 
+	a.runOptInRules(pass, insp)
+
 	return nil, nil
+}
+
+// runOptInRules runs the house-style rules that are off unless their flag is
+// set. Each is skipped entirely when disabled, so the default rule set — and
+// therefore the default output — is exactly what it was before they existed.
+//
+// They need the enclosing function to decide where a *qt.C would be created,
+// which Preorder does not provide, so they get their own WithStack traversal.
+func (a *analyzer) runOptInRules(pass *analysis.Pass, insp *inspector.Inspector) {
+	if !a.requireQtCReceiver {
+		return
+	}
+
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+	}
+
+	insp.WithStack(nodeFilter, func(n ast.Node, push bool, stack []ast.Node) bool {
+		if !push {
+			return false
+		}
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if a.requireQtCReceiver {
+			checkRequireQtCReceiver(pass, stack, call)
+		}
+		return true
+	})
 }
 
 // checkQuicktestCall checks if a call expression is a quicktest assertion

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -34,4 +34,25 @@ func TestFixes(t *testing.T) {
 		}
 		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "errcheckonlystable")
 	})
+
+	t.Run("qtcreceiverfix", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-qt-c-receiver")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "qtcreceiverfix")
+	})
+
+	// Nothing this rule rewrites can change runtime behavior, so
+	// --only-stable-fixes withholds nothing: the same golden must hold.
+	t.Run("qtcreceiverfix only-stable-fixes", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-qt-c-receiver")
+		setFlag(t, analyzer, "only-stable-fixes")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "qtcreceiverfix")
+	})
+
+	t.Run("qtcreceiveralias", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-qt-c-receiver")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "qtcreceiveralias")
+	})
 }

--- a/qtlint_golden_test.go
+++ b/qtlint_golden_test.go
@@ -1,0 +1,99 @@
+package qtlint_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/packages"
+)
+
+// TestGoldenFilesCompile type-checks the result of every suggested fix.
+//
+// The analysistest harness compares fixed source against the .golden file
+// after gofmt, and gofmt accepts a great deal that the type checker does not:
+// a rewrite that leaves a variable unused, or that names one which is not in
+// scope, passes TestFixes and is still worthless. This test rebuilds the
+// testdata tree with every .golden file standing in for the file it belongs
+// to and loads the result, so a fix that does not compile fails here.
+func TestGoldenFilesCompile(t *testing.T) {
+	staged := t.TempDir()
+	golden := stageGoldenTree(t, filepath.Join(analysistest.TestData(), "src"), filepath.Join(staged, "src"))
+	if golden == 0 {
+		t.Fatal("no .golden files were staged; the test would prove nothing")
+	}
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports,
+		Dir:   filepath.Join(staged, "src"),
+		Env:   append(os.Environ(), "GOPATH="+staged, "GO111MODULE=off", "GOWORK=off"),
+		Tests: false,
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("load staged testdata: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("no packages loaded from the staged testdata")
+	}
+
+	packages.Visit(pkgs, nil, func(pkg *packages.Package) {
+		for _, e := range pkg.Errors {
+			t.Errorf("%s: %v", pkg.PkgPath, e)
+		}
+	})
+}
+
+// stageGoldenTree copies the tree rooted at src into dst, substituting the
+// content of x.go.golden for x.go wherever a golden file exists. It returns
+// the number of substitutions made.
+func stageGoldenTree(t *testing.T, src, dst string) int {
+	t.Helper()
+
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		t.Fatalf("create staging root: %v", err)
+	}
+	srcRoot, err := os.OpenRoot(src)
+	if err != nil {
+		t.Fatalf("open testdata root: %v", err)
+	}
+	t.Cleanup(func() { _ = srcRoot.Close() })
+	dstRoot, err := os.OpenRoot(dst)
+	if err != nil {
+		t.Fatalf("open staging root: %v", err)
+	}
+	t.Cleanup(func() { _ = dstRoot.Close() })
+
+	var golden int
+	err = fs.WalkDir(srcRoot.FS(), ".", func(rel string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case rel == ".":
+			return nil
+		case d.IsDir():
+			return dstRoot.MkdirAll(rel, 0o750)
+		case strings.HasSuffix(rel, ".golden"):
+			return nil
+		}
+
+		source := rel
+		if _, err := fs.Stat(srcRoot.FS(), rel+".golden"); err == nil {
+			source = rel + ".golden"
+			golden++
+		}
+		content, err := srcRoot.ReadFile(source)
+		if err != nil {
+			return err
+		}
+		return dstRoot.WriteFile(rel, content, 0o600)
+	})
+	if err != nil {
+		t.Fatalf("stage testdata: %v", err)
+	}
+	return golden
+}

--- a/qtlint_test.go
+++ b/qtlint_test.go
@@ -3,6 +3,7 @@ package qtlint_test
 import (
 	"testing"
 
+	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/analysistest"
 
 	"github.com/go-extras/qtlint"
@@ -70,4 +71,26 @@ func TestAnalyzer(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		analysistest.Run(t, testdata, analyzer, "equalsnil")
 	})
+
+	t.Run("require-qt-c-receiver patterns", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-qt-c-receiver")
+		analysistest.Run(t, testdata, analyzer, "qtcreceiver")
+	})
+
+	// The flag gate's control: the same calls, with no want comments, run
+	// through an analyzer that was never told to enable the rule.
+	t.Run("require-qt-c-receiver is off by default", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		analysistest.Run(t, testdata, analyzer, "qtcreceiveroff")
+	})
+}
+
+// setFlag enables a boolean analyzer flag, failing the test if the flag does
+// not exist.
+func setFlag(t *testing.T, analyzer *analysis.Analyzer, name string) {
+	t.Helper()
+	if err := analyzer.Flags.Set(name, "true"); err != nil {
+		t.Fatalf("set flag %s: %v", name, err)
+	}
 }

--- a/requireqtcreceiver.go
+++ b/requireqtcreceiver.go
@@ -1,0 +1,160 @@
+package qtlint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// packageLevelAssertion describes a qt.Assert(t, …) or qt.Check(t, …) call
+// whose first argument is an identifier of type *testing.T.
+type packageLevelAssertion struct {
+	// sel is the call's "qt.Assert" selector.
+	sel *ast.SelectorExpr
+	// method is "Assert" or "Check".
+	method string
+	// qtAlias is the name the file imports quicktest under.
+	qtAlias string
+	// tIdent is the *testing.T argument that would be dropped.
+	tIdent *ast.Ident
+	// tObj is the object tIdent refers to.
+	tObj types.Object
+}
+
+// matchPackageLevelAssertion parses call into a packageLevelAssertion.
+//
+// The first argument must be an identifier of type *testing.T, because
+// quicktest accepts any testing.TB there and a project may legitimately pass
+// a *testing.B or a testing.TB obtained elsewhere. The rewrite this rule
+// suggests has no defensible shape for those, so the rule stays out of them.
+func matchPackageLevelAssertion(pass *analysis.Pass, call *ast.CallExpr) (packageLevelAssertion, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return packageLevelAssertion{}, false
+	}
+
+	method := sel.Sel.Name
+	if method != "Assert" && method != "Check" {
+		return packageLevelAssertion{}, false
+	}
+	if !isPackageQualified(pass, sel) {
+		return packageLevelAssertion{}, false
+	}
+	pkgIdent, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return packageLevelAssertion{}, false
+	}
+
+	// The package-level form is qt.Assert(t, got, checker, …); anything
+	// shorter than "t, got" cannot be the shape we rewrite.
+	if len(call.Args) < 2 {
+		return packageLevelAssertion{}, false
+	}
+	tIdent, ok := call.Args[0].(*ast.Ident)
+	if !ok {
+		return packageLevelAssertion{}, false
+	}
+	tObj := pass.TypesInfo.Uses[tIdent]
+	if tObj == nil || !isTestingTPtr(tObj.Type()) {
+		return packageLevelAssertion{}, false
+	}
+
+	return packageLevelAssertion{
+		sel:     sel,
+		method:  method,
+		qtAlias: pkgIdent.Name,
+		tIdent:  tIdent,
+		tObj:    tObj,
+	}, true
+}
+
+// checkRequireQtCReceiver reports a package-level qt.Assert/qt.Check and
+// suggests the *qt.C method form.
+//
+// The fix reuses a *qt.C that was created from the same *testing.T when one
+// is visible, and otherwise creates one as the first statement of the
+// function that binds that *testing.T — the function whose parameter list
+// declares it, which is the subtest closure rather than the parent test when
+// the assertion sits inside one.
+func checkRequireQtCReceiver(pass *analysis.Pass, stack []ast.Node, call *ast.CallExpr) {
+	m, ok := matchPackageLevelAssertion(pass, call)
+	if !ok {
+		return
+	}
+
+	// qt.New(t) can only be written where t is visible, so the function
+	// binding t bounds both the search for an existing *qt.C and the place
+	// a new one is created.
+	body := enclosingBindingBody(pass, stack, m.tObj)
+	if body == nil {
+		return
+	}
+
+	edits := make([]analysis.TextEdit, 0, 3)
+	cName, reused := visibleQtCFrom(pass, body, m.tObj, call.Pos())
+	if !reused {
+		cName = freeName("c", identNamesIn(body))
+		edits = append(edits, prependStmtEdit(body,
+			fmt.Sprintf("%s := %s.New(%s)", cName, m.qtAlias, m.tIdent.Name)))
+	}
+
+	// qt.Assert(t, got, …) becomes c.Assert(got, …): retarget the selector,
+	// then drop the receiver argument along with the comma that follows it.
+	edits = append(edits,
+		analysis.TextEdit{
+			Pos:     m.sel.X.Pos(),
+			End:     m.sel.Sel.Pos(),
+			NewText: []byte(cName + "."),
+		},
+		analysis.TextEdit{
+			Pos: call.Args[0].Pos(),
+			End: call.Args[1].Pos(),
+		},
+	)
+
+	pass.Report(analysis.Diagnostic{
+		Pos: call.Pos(),
+		End: call.End(),
+		Message: fmt.Sprintf("qtlint: use %s.%s(...) instead of %s.%s(%s, ...)",
+			cName, m.method, m.qtAlias, m.method, m.tIdent.Name),
+		SuggestedFixes: []analysis.SuggestedFix{{
+			Message:   fmt.Sprintf("Replace with %s.%s", cName, m.method),
+			TextEdits: edits,
+		}},
+	})
+}
+
+// visibleQtCFrom returns the name of a *qt.C that was created from tObj by a
+// qt.New call inside body and is, under that name, the object that name
+// resolves to at pos.
+//
+// The resolution check is what keeps the rewrite honest: a *qt.C named c in
+// an enclosing test is not interchangeable with the t of a subtest closure,
+// and reusing it would move the assertion onto the parent test.
+func visibleQtCFrom(pass *analysis.Pass, body *ast.BlockStmt, tObj types.Object, pos token.Pos) (string, bool) {
+	scope := pass.Pkg.Scope().Innermost(pos)
+	if scope == nil {
+		return "", false
+	}
+
+	var best types.Object
+	for obj, arg := range collectQtCOrigins(pass, body) {
+		ident, ok := arg.(*ast.Ident)
+		if !ok || pass.TypesInfo.Uses[ident] != tObj {
+			continue
+		}
+		if _, found := scope.LookupParent(obj.Name(), pos); found != obj {
+			continue
+		}
+		if best == nil || obj.Pos() < best.Pos() {
+			best = obj
+		}
+	}
+	if best == nil {
+		return "", false
+	}
+	return best.Name(), true
+}

--- a/testdata/src/github.com/frankban/quicktest/quicktest.go
+++ b/testdata/src/github.com/frankban/quicktest/quicktest.go
@@ -51,6 +51,7 @@ var (
 	Equals     Checker
 	DeepEquals Checker
 	HasLen     Checker
+	Contains   Checker
 	ErrorIs    Checker
 	ErrorAs    Checker
 )

--- a/testdata/src/qtcreceiver/qtcreceiver.go
+++ b/testdata/src/qtcreceiver/qtcreceiver.go
@@ -1,0 +1,86 @@
+package qtcreceiver
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Case 1: a *qt.C created from this t is already in scope, so the fix reuses
+// it rather than creating a second one.
+func TestExistingC(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	qt.Check(t, 2, qt.Equals, 2)  // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+}
+
+// Case 2: no *qt.C is in scope, so the fix creates one in the function that
+// binds t.
+func TestNoC(t *testing.T) {
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	qt.Check(t, 2, qt.Equals, 2)  // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+}
+
+// Case 3: a helper taking its own *testing.T gets its own *qt.C; nothing is
+// smuggled in from a caller.
+func assertOne(t *testing.T, got int) {
+	qt.Assert(t, got, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The insertion point is the function that binds the t being asserted
+// against, which here is the subtest closure and not the parent test.
+func TestSubtest(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	t.Run("sub", func(t *testing.T) {
+		qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	})
+}
+
+// The name c is taken by something that is not a *qt.C, so the fix picks the
+// next free name instead of declining.
+func TestNameTaken(t *testing.T) {
+	c := 42
+	qt.Assert(t, c, qt.Equals, 42) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// A *qt.C built from a different *testing.T is not reused: c belongs to the
+// subtest, and the assertion is against the parent's t.
+func TestOtherT(t *testing.T) {
+	t.Run("sub", func(inner *testing.T) {
+		c := qt.New(inner)
+		c.Assert(0, qt.Equals, 0)
+
+		qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	})
+}
+
+// Not reported: the assertion already goes through a *qt.C.
+func TestAlreadyOnC(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(1, qt.Equals, 1)
+	c.Check(2, qt.Equals, 2)
+}
+
+// Not reported: the first argument is a *testing.B, not a *testing.T.
+func BenchmarkOther(b *testing.B) {
+	qt.Assert(b, 1, qt.Equals, 1)
+}
+
+// Not reported: the first argument is a testing.TB, not a *testing.T.
+func assertTB(tb testing.TB) {
+	qt.Assert(tb, 1, qt.Equals, 1)
+}
+
+// Not reported: the first argument is not an identifier, so there is no
+// binding function to create a *qt.C in.
+type harness struct {
+	t *testing.T
+}
+
+func (h harness) assert() {
+	qt.Assert(h.t, 1, qt.Equals, 1)
+}

--- a/testdata/src/qtcreceiver/qtcreceiver.go
+++ b/testdata/src/qtcreceiver/qtcreceiver.go
@@ -47,6 +47,15 @@ func TestNameTaken(t *testing.T) {
 	qt.Assert(t, c, qt.Equals, 42) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
 }
 
+// A *qt.C that is declared further down is not reused: the rewritten call
+// would name it before its declaration.
+func TestDeclaredLater(t *testing.T) {
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+
+	c := qt.New(t)
+	c.Assert(2, qt.Equals, 2)
+}
+
 // A *qt.C built from a different *testing.T is not reused: c belongs to the
 // subtest, and the assertion is against the parent's t.
 func TestOtherT(t *testing.T) {

--- a/testdata/src/qtcreceiveralias/qtcreceiveralias.go
+++ b/testdata/src/qtcreceiveralias/qtcreceiveralias.go
@@ -1,0 +1,23 @@
+package qtcreceiveralias
+
+import (
+	"testing"
+
+	myqt "github.com/frankban/quicktest"
+)
+
+// The rule resolves the quicktest package through the type checker, exactly
+// as the default rules do, so an alias other than qt is matched and the fix
+// writes the alias the file actually uses.
+func TestAlias(t *testing.T) {
+	myqt.Assert(t, 1, myqt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of myqt.Assert\\(t, ...\\)"
+	myqt.Check(t, 2, myqt.Equals, 2)  // want "qtlint: use c.Check\\(...\\) instead of myqt.Check\\(t, ...\\)"
+}
+
+// An aliased import is also what a reused *qt.C is found through.
+func TestAliasExistingC(t *testing.T) {
+	qc := myqt.New(t)
+	qc.Assert(0, myqt.Equals, 0)
+
+	myqt.Assert(t, 1, myqt.Equals, 1) // want "qtlint: use qc.Assert\\(...\\) instead of myqt.Assert\\(t, ...\\)"
+}

--- a/testdata/src/qtcreceiveralias/qtcreceiveralias.go.golden
+++ b/testdata/src/qtcreceiveralias/qtcreceiveralias.go.golden
@@ -1,0 +1,24 @@
+package qtcreceiveralias
+
+import (
+	"testing"
+
+	myqt "github.com/frankban/quicktest"
+)
+
+// The rule resolves the quicktest package through the type checker, exactly
+// as the default rules do, so an alias other than qt is matched and the fix
+// writes the alias the file actually uses.
+func TestAlias(t *testing.T) {
+	c := myqt.New(t)
+	c.Assert(1, myqt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of myqt.Assert\\(t, ...\\)"
+	c.Check(2, myqt.Equals, 2)  // want "qtlint: use c.Check\\(...\\) instead of myqt.Check\\(t, ...\\)"
+}
+
+// An aliased import is also what a reused *qt.C is found through.
+func TestAliasExistingC(t *testing.T) {
+	qc := myqt.New(t)
+	qc.Assert(0, myqt.Equals, 0)
+
+	qc.Assert(1, myqt.Equals, 1) // want "qtlint: use qc.Assert\\(...\\) instead of myqt.Assert\\(t, ...\\)"
+}

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go
@@ -1,0 +1,44 @@
+package qtcreceiverfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Case 1: an existing *qt.C built from this t is reused.
+func TestExistingC(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	qt.Check(t, 2, qt.Equals, 2)  // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+}
+
+// Case 2: a *qt.C is created once, however many assertions need it.
+func TestNoC(t *testing.T) {
+	qt.Assert(t, 1, qt.Equals, 1)                        // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	qt.Check(t, 2, qt.Equals, 2)                         // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+	qt.Assert(t, 3, qt.Equals, 3, qt.Commentf("third")) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// Case 3: the helper gets its own *qt.C.
+func assertOne(t *testing.T, got int) {
+	qt.Assert(t, got, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The subtest closure binds t, so that is where the *qt.C is created.
+func TestSubtest(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	t.Run("sub", func(t *testing.T) {
+		qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	})
+}
+
+// The name c is taken, so the next free one is used.
+func TestNameTaken(t *testing.T) {
+	c := 42
+	qt.Assert(t, c, qt.Equals, 42) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go
@@ -42,3 +42,12 @@ func TestNameTaken(t *testing.T) {
 	c := 42
 	qt.Assert(t, c, qt.Equals, 42) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
 }
+
+// A *qt.C declared further down is not reused: naming it here would put the
+// reference before its declaration.
+func TestDeclaredLater(t *testing.T) {
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+
+	c := qt.New(t)
+	c.Assert(2, qt.Equals, 2)
+}

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
@@ -1,0 +1,48 @@
+package qtcreceiverfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Case 1: an existing *qt.C built from this t is reused.
+func TestExistingC(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	c.Assert(1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	c.Check(2, qt.Equals, 2)  // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+}
+
+// Case 2: a *qt.C is created once, however many assertions need it.
+func TestNoC(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(1, qt.Equals, 1)                       // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	c.Check(2, qt.Equals, 2)                        // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+	c.Assert(3, qt.Equals, 3, qt.Commentf("third")) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// Case 3: the helper gets its own *qt.C.
+func assertOne(t *testing.T, got int) {
+	c := qt.New(t)
+	c.Assert(got, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The subtest closure binds t, so that is where the *qt.C is created.
+func TestSubtest(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	})
+}
+
+// The name c is taken, so the next free one is used.
+func TestNameTaken(t *testing.T) {
+	c2 := qt.New(t)
+	c := 42
+	c2.Assert(c, qt.Equals, 42) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
@@ -46,3 +46,14 @@ func TestNameTaken(t *testing.T) {
 	c := 42
 	c2.Assert(c, qt.Equals, 42) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
 }
+
+// A *qt.C declared further down is not reused: naming it here would put the
+// reference before its declaration.
+func TestDeclaredLater(t *testing.T) {
+	c2 := qt.New(t)
+	c2.Assert(1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+
+	c := qt.New(t)
+	c.Assert(2, qt.Equals, 2)
+}
+

--- a/testdata/src/qtcreceiveroff/qtcreceiveroff.go
+++ b/testdata/src/qtcreceiveroff/qtcreceiveroff.go
@@ -1,0 +1,29 @@
+package qtcreceiveroff
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// This package is the flag gate's control. Every call below is exactly what
+// -require-qt-c-receiver reports, and none of them carries a want comment:
+// the test runs it with a default analyzer, so a diagnostic here is a
+// failure. If the rule ever fires without its flag, this package goes red.
+func TestNotReportedByDefault(t *testing.T) {
+	qt.Assert(t, 1, qt.Equals, 1)
+	qt.Check(t, 2, qt.Equals, 2)
+}
+
+func assertOne(t *testing.T, got int) {
+	qt.Assert(t, got, qt.Equals, 1)
+}
+
+func TestSubtestNotReportedByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	t.Run("sub", func(t *testing.T) {
+		qt.Assert(t, 1, qt.Equals, 1)
+	})
+}


### PR DESCRIPTION
Closes #41.

## What this adds

`-require-qt-c-receiver`, a house-style rule that is **off by default**. When enabled it reports every `qt.Assert(t, …)` and `qt.Check(t, …)` whose first argument is an identifier of type `*testing.T`, and suggests the `*qt.C` method form.

Both forms are correct quicktest, which is why this is behind a flag rather than in the default rule set — the same precedent `-only-stable-fixes` set for flag-gated behavior.

## The fix

Every reported call ships a `SuggestedFix`. There are two shapes:

1. **A `*qt.C` created from the same `*testing.T` is already visible.** The call is retargeted onto it and the `t` argument dropped. "Visible" means the variable's own name resolves to *that* object at the call site, which is what stops the rewrite from reusing an enclosing test's `c` for an assertion made against a subtest's `t`, and from naming a `c` that is declared further down the function.
2. **No such `*qt.C` is visible.** The fix inserts `c := qt.New(t)` as the first statement of the function that *binds* that `*testing.T` — the function whose parameter list declares it. That is the subtest closure when the assertion sits inside one, and the helper's own body when it sits in a helper taking `t *testing.T`; nothing is smuggled in from a caller. Where the name `c` is already taken in that function, the next free name (`c2`, `c3`, …) is used rather than declining.

`-only-stable-fixes` withholds nothing here. It exists for rewrites that can change runtime behavior, and creating a `*qt.C` from a `*testing.T` cannot: the assertion runs against the same test either way. The test suite asserts this by running the fix package twice, with and without `-only-stable-fixes`, against the same golden.

Issue #41's acceptance list says cases 2 and 3 should report without a fix under `-only-stable-fixes`, which contradicts the issue body two paragraphs above it ("None of the three above qualifies"). This implements the body.

## What the rule declines

- The first argument is not an identifier of type `*testing.T` — a `*testing.B`, a bare `testing.TB`, or a field selector like `h.t`. `qt.Assert` accepts any `testing.TB`, and a project may legitimately pass something else.
- No function on the enclosing stack binds that identifier as a parameter, so there is nowhere to put the `qt.New` call.

An aliased quicktest import is matched the way the default rules match it — through the type checker, not the identifier — and the fix writes whichever alias the file uses.

## Default rule set

Unchanged, and measured rather than asserted. With the flag absent the analyzer does not run the traversal at all. Running the binary built from this branch with no flags over a frozen copy of the pre-change `testdata/src` corpus produces output byte-identical to the binary built from `cd48a66`:

```
$ cmp corpus-baseline.txt corpus-final41.txt   # exit 0, 191 lines, sha256 5bf0c7eb…
```

The measurement is not vacuous: the same binary with `-require-qt-c-receiver` on the same corpus goes from 191 to 294 diagnostic lines.

## New: TestGoldenFilesCompile

`analysistest.RunWithSuggestedFixes` compares fixed source against the `.golden` file after gofmt, and gofmt accepts a great deal the type checker does not — a rewrite that leaves a variable unused, or names one that is not in scope, passes `TestFixes` and is still worthless. The new test stages the testdata tree with every `.golden` standing in for the file it belongs to and type-checks the result.

It found a pre-existing hole on its first run: the quicktest stub declared no `Contains` checker, so `strcontainsfix.go.golden` and `aliascontainsfix.go.golden` — rule 7's own output — had never compiled. The stub now declares it. That is the only change to existing testdata, and it does not move any diagnostic.

## Testdata

| package | what it pins |
| --- | --- |
| `qtcreceiver` | all three fix shapes, the subtest and helper binders, the `c`-is-taken and declared-later cases, plus the four shapes that must **not** fire |
| `qtcreceiverfix` | the same fixable shapes with a golden, run twice — with and without `-only-stable-fixes` |
| `qtcreceiveralias` | an aliased `myqt` import, with a golden |
| `qtcreceiveroff` | the flag gate's control: the exact calls the rule reports, with no `want` comments, run through a default analyzer |

## Mutants

Each is the cheaper wrong implementation, compiling, applied and reverted.

| mutant | RED | stayed green |
| --- | --- | --- |
| the flag gate ignored (`runOptInRules` always runs) | `qtcreceiveroff` reports 4 unexpected diagnostics; 9 pre-existing packages break; `cmp` against the baseline corpus fails at char 998 | `method_calls`, `errcheck`, `require-qt-c-receiver patterns`, all `TestFixes` |
| the fix rewrites the call but never creates the `*qt.C` | `TestFixes/qtcreceiverfix`, `/qtcreceiverfix only-stable-fixes`, `/qtcreceiveralias` | every `TestAnalyzer` subtest, including `require-qt-c-receiver patterns` — the diagnostic is right and only the fix is wrong, which is what separates the two |
| the same mutant with the goldens regenerated to match it | `TestGoldenFilesCompile` alone: `undefined: c`, `undefined: c2` | every `TestFixes` subtest — the case the compile gate exists for |
| reuse any visible `*qt.C`, ignoring which `*testing.T` it came from | `require-qt-c-receiver patterns` at `qtcreceiver.go:66` — the parent's assertion silently rebinds to the subtest's `c` | everything else |
| drop the declared-before-use check (`LookupParent` with `token.NoPos`) | `require-qt-c-receiver patterns` at `qtcreceiver.go:53` and `TestFixes/qtcreceiverfix` at `:49` | everything else |

## Fix applied end to end

Building the binary, running `qtlint -fix -require-qt-c-receiver ./...` over the whole testdata corpus, then building it: exit 0 before, exit 0 after, and a re-lint reports no remaining `require-qt-c-receiver` diagnostics.

## Gates

`go build ./...` 0 · `go vet ./...` 0 · `go test ./... -count=1` 0 · `go test -race ./... -count=1` 0 · `golangci-lint run ./...` 0 (0 issues) · `go mod tidy` + `git diff --exit-code go.mod go.sum` 0 · `make build` 0 · `make lint` 0 · coverage 82.6% against the 50% CI threshold.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in `require-qt-c-receiver` lint rule.
  * Detects package-level Quicktest assertions and recommends receiver-based syntax.
  * Provides automatic fixes, reusing or creating suitable receivers as needed.
  * Supports aliased Quicktest imports and nested test functions.

* **Documentation**
  * Added configuration details, behavior notes, and usage examples.

* **Tests**
  * Added coverage for diagnostics, autofixes, aliases, edge cases, and default-disabled behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->