### PR TITLE
fix: two review findings in -require-qt-c-receiver

### DIFF
--- a/qtcbinding.go
+++ b/qtcbinding.go
@@ -69,10 +69,15 @@ func freeName(base string, taken map[string]bool) string {
 // any other way (a parameter, a struct field, a helper's return value) has no
 // statically known testing.TB behind it, which is why the rules below decline
 // to reason about it.
+//
+// A variable that is written again after its declaration is dropped, because
+// the declaration is no longer a true statement about which test the *qt.C
+// holds. See invalidateRebound.
 func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.Expr {
 	origins := make(map[types.Object]ast.Expr)
 
-	record := func(name, value ast.Expr) {
+	declaredAt := make(map[types.Object]ast.Node)
+	record := func(name, value ast.Expr, decl ast.Node) {
 		ident, ok := name.(*ast.Ident)
 		if !ok {
 			return
@@ -83,6 +88,7 @@ func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.
 		}
 		if arg, ok := qtNewArg(pass, value); ok {
 			origins[obj] = arg
+			declaredAt[obj] = decl
 		}
 	}
 
@@ -90,7 +96,7 @@ func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.
 		switch stmt := n.(type) {
 		case *ast.AssignStmt:
 			if stmt.Tok == token.DEFINE && len(stmt.Lhs) == 1 && len(stmt.Rhs) == 1 {
-				record(stmt.Lhs[0], stmt.Rhs[0])
+				record(stmt.Lhs[0], stmt.Rhs[0], stmt)
 			}
 		case *ast.DeclStmt:
 			collectQtCVarSpecs(stmt, record)
@@ -98,12 +104,61 @@ func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.
 		return true
 	})
 
+	invalidateRebound(pass, root, origins, declaredAt)
+
 	return origins
+}
+
+// invalidateRebound drops every origin whose variable is written again after
+// its declaration, or whose address is taken.
+//
+// An origin is only useful as a claim about which testing.TB a *qt.C holds.
+// "c := qt.New(t); c = qt.New(other)" makes that claim false from the second
+// statement onwards, and a rewrite that believed it would move assertions
+// onto a different test — silently, since both spellings compile. Taking the
+// variable's address puts the same write out of reach of this analysis, so it
+// is treated the same way.
+func invalidateRebound(
+	pass *analysis.Pass,
+	root ast.Node,
+	origins map[types.Object]ast.Expr,
+	declaredAt map[types.Object]ast.Node,
+) {
+	drop := func(expr ast.Expr, at ast.Node) {
+		ident, ok := stripParens(expr).(*ast.Ident)
+		if !ok {
+			return
+		}
+		obj := pass.TypesInfo.Uses[ident]
+		if obj == nil {
+			obj = pass.TypesInfo.Defs[ident]
+		}
+		if _, ok := origins[obj]; ok && declaredAt[obj] != at {
+			delete(origins, obj)
+		}
+	}
+
+	ast.Inspect(root, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			for _, lhs := range node.Lhs {
+				drop(lhs, node)
+			}
+		case *ast.RangeStmt:
+			drop(node.Key, node)
+			drop(node.Value, node)
+		case *ast.UnaryExpr:
+			if node.Op == token.AND {
+				drop(node.X, nil)
+			}
+		}
+		return true
+	})
 }
 
 // collectQtCVarSpecs feeds every single-name, single-value var specification
 // in stmt to record.
-func collectQtCVarSpecs(stmt *ast.DeclStmt, record func(name, value ast.Expr)) {
+func collectQtCVarSpecs(stmt *ast.DeclStmt, record func(name, value ast.Expr, decl ast.Node)) {
 	decl, ok := stmt.Decl.(*ast.GenDecl)
 	if !ok || decl.Tok != token.VAR {
 		return
@@ -113,7 +168,7 @@ func collectQtCVarSpecs(stmt *ast.DeclStmt, record func(name, value ast.Expr)) {
 		if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
 			continue
 		}
-		record(vs.Names[0], vs.Values[0])
+		record(vs.Names[0], vs.Values[0], stmt)
 	}
 }
 
@@ -148,23 +203,31 @@ func funcBindsObject(pass *analysis.Pass, params *ast.FieldList, obj types.Objec
 	return false
 }
 
-// enclosingBindingBody returns the body of the innermost function on stack
-// whose parameter list declares obj, or nil when no function on the stack
-// does.
-func enclosingBindingBody(pass *analysis.Pass, stack []ast.Node, obj types.Object) *ast.BlockStmt {
+// enclosingBinder returns the innermost function on stack whose parameter
+// list declares obj, together with that function's body. Both are nil when no
+// function on the stack declares it.
+//
+// Callers need both halves and they are not interchangeable. The body is
+// where a new statement goes; the whole function is what a new name must not
+// collide with. A receiver, a parameter and a named result share one scope
+// with the body, so "c := qt.New(t)" prepended to the body of
+// "func (c *harness) assert(t *testing.T)" is "no new variables on left side
+// of :=" — a name that is taken outside the body but inside the scope the
+// body writes into.
+func enclosingBinder(pass *analysis.Pass, stack []ast.Node, obj types.Object) (ast.Node, *ast.BlockStmt) {
 	for i := len(stack) - 1; i >= 0; i-- {
 		switch fn := stack[i].(type) {
 		case *ast.FuncDecl:
 			if funcBindsObject(pass, fn.Type.Params, obj) {
-				return fn.Body
+				return fn, fn.Body
 			}
 		case *ast.FuncLit:
 			if funcBindsObject(pass, fn.Type.Params, obj) {
-				return fn.Body
+				return fn, fn.Body
 			}
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // prependStmtEdit returns the edit that makes code the first statement of

--- a/requireqtcreceiver.go
+++ b/requireqtcreceiver.go
@@ -88,7 +88,7 @@ func checkRequireQtCReceiver(pass *analysis.Pass, stack []ast.Node, call *ast.Ca
 	// qt.New(t) can only be written where t is visible, so the function
 	// binding t bounds both the search for an existing *qt.C and the place
 	// a new one is created.
-	body := enclosingBindingBody(pass, stack, m.tObj)
+	binder, body := enclosingBinder(pass, stack, m.tObj)
 	if body == nil {
 		return
 	}
@@ -96,7 +96,9 @@ func checkRequireQtCReceiver(pass *analysis.Pass, stack []ast.Node, call *ast.Ca
 	edits := make([]analysis.TextEdit, 0, 3)
 	cName, reused := visibleQtCFrom(pass, body, m.tObj, call.Pos())
 	if !reused {
-		cName = freeName("c", identNamesIn(body))
+		// The name is taken from the whole function, not just its body: a
+		// receiver, parameter or named result shares the body's scope.
+		cName = freeName("c", identNamesIn(binder))
 		edits = append(edits, prependStmtEdit(body,
 			fmt.Sprintf("%s := %s.New(%s)", cName, m.qtAlias, m.tIdent.Name)))
 	}

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go
@@ -51,3 +51,33 @@ func TestDeclaredLater(t *testing.T) {
 	c := qt.New(t)
 	c.Assert(2, qt.Equals, 2)
 }
+
+// A *qt.C that is assigned again is not reused. Its declaration no longer
+// says which test it holds, and reusing it would run the assertion against
+// other rather than against t.
+func assertRebound(t, other *testing.T) {
+	c := qt.New(t)
+	c = qt.New(other)
+	c.Assert(0, qt.Equals, 0)
+
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The name c is taken by a parameter the body never mentions. Parameters
+// share the body's scope, so c := qt.New(t) here would not declare anything.
+func assertUnusedParam(t *testing.T, c int) {
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+type harness struct{}
+
+// The name c is taken by a method receiver.
+func (c harness) assert(t *testing.T) {
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The name c is taken by a named result.
+func assertNamedResult(t *testing.T) (c int) {
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	return 0
+}

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
@@ -57,3 +57,37 @@ func TestDeclaredLater(t *testing.T) {
 	c.Assert(2, qt.Equals, 2)
 }
 
+// A *qt.C that is assigned again is not reused. Its declaration no longer
+// says which test it holds, and reusing it would run the assertion against
+// other rather than against t.
+func assertRebound(t, other *testing.T) {
+	c2 := qt.New(t)
+	c := qt.New(t)
+	c = qt.New(other)
+	c.Assert(0, qt.Equals, 0)
+
+	c2.Assert(1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The name c is taken by a parameter the body never mentions. Parameters
+// share the body's scope, so c := qt.New(t) here would not declare anything.
+func assertUnusedParam(t *testing.T, c int) {
+	c2 := qt.New(t)
+	c2.Assert(1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+type harness struct{}
+
+// The name c is taken by a method receiver.
+func (c harness) assert(t *testing.T) {
+	c2 := qt.New(t)
+	c2.Assert(1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+}
+
+// The name c is taken by a named result.
+func assertNamedResult(t *testing.T) (c int) {
+	c2 := qt.New(t)
+	c2.Assert(1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	return 0
+}
+


### PR DESCRIPTION
Follow-up to #43. Two of the three review findings on that pull request are real; this fixes both and pins each with testdata. The third is answered below rather than changed.

## 1. A reused `*qt.C` that was reassigned

`collectQtCOrigins` recorded a variable's initializer and nothing else, so a later write went unnoticed:

```go
func assertRebound(t, other *testing.T) {
    c := qt.New(t)
    c = qt.New(other)
    qt.Assert(t, 1, qt.Equals, 1)   // rewritten to c.Assert(1, …)
}
```

By the time the assertion runs, `c` belongs to `other`. The rewrite therefore moves the assertion onto a different test — silently, because both spellings compile and the diagnostic reads the same either way. That is exactly the failure the reuse path was built to avoid; it just had one more way in than the `*testing.T` identity check covered.

`invalidateRebound` now drops an origin whose variable is assigned again after its declaration, appears as a range key or value, or has its address taken. The rule then falls back to creating its own `*qt.C`, which is sound whatever the old variable holds.

## 2. The new `*qt.C`'s name collided with a receiver, parameter or named result

The name was chosen with `freeName("c", identNamesIn(body))` — identifiers appearing in the binding function's **body**. A receiver, a parameter and a named result are declared outside the body and share one scope with it, so a binder that declared `c` there and never mentioned it inside got `c := qt.New(t)` prepended and failed to build. Confirmed against the compiler:

```
./scopecheck.go:6:4: no new variables on left side of :=    // func (c *widget) …
./scopecheck.go:11:4: no new variables on left side of :=   // func f(c int)
./scopecheck.go:16:4: no new variables on left side of :=   // func f() (c int)
```

`enclosingBindingBody` becomes `enclosingBinder` and returns the function node alongside the body. The two are not interchangeable and both are needed: the body is where the statement goes, the whole function is what the name must not collide with. That is the signature change the shared helper needed rather than a second copy of it next to the first.

## 3. markdownlint MD040 — not changed, deliberately

The finding is that the new rule's **Error message** block is fenced without a language. It is, and so is every other error-message block in the README — all eleven of them, from rule 1 down. There is no markdownlint step in either workflow, so this is not a gate; labelling one block out of twelve would make the file less consistent, not more. If the owner wants the file linted, that is a separate sweep over all of them.

## Testdata

Four cases in `qtcreceiverfix`, one per shape, each carrying its `want` and its golden:

- `assertRebound` — the reassigned receiver
- `assertUnusedParam` — `c` taken by a parameter the body never mentions
- `harness.assert` — `c` taken by a method receiver
- `assertNamedResult` — `c` taken by a named result

All four now rewrite to `c2`, and `TestGoldenFilesCompile` is what proves the results build. Before this change three of them produced source the compiler rejects, which is precisely the property that test exists to hold.

## Mutants

Both are the implementation as it shipped in #43, restored and reverted.

| mutant | RED | stayed green |
| --- | --- | --- |
| `invalidateRebound` not called | `TestFixes/qtcreceiverfix` and `/qtcreceiverfix only-stable-fixes` at `qtcreceiverfix.go:63` — the rewrite reuses the rebound `c` | every `TestAnalyzer` subtest and the other two `TestFixes` subtests |
| the name taken from `identNamesIn(body)` | the same two subtests at `:69`, `:76` and `:81` — the parameter, receiver and named-result binders | same |

`TestGoldenFilesCompile` stays green under both, as it must: it reads the committed goldens, which the mutants do not touch. It is the diagnostic expectations that catch these, and the goldens that record the compiling result.

## Default rule set

Still untouched, measured the same way as in #43: the binary built from this branch, run with no flags over a frozen copy of the pre-change corpus, is byte-identical to the `cd48a66` baseline (`cmp` exit 0).

## Gates

`go build ./...` 0 · `go vet ./...` 0 · `go test ./... -count=1` 0 · `golangci-lint run ./...` 0 (0 issues).
