### PR TITLE
feat: add opt-in -require-testing-run rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This ensures that tests use the most direct and readable checker available.
 A second, smaller group of rules is **opt-in and off by default**. They choose between two forms that are both correct quicktest, so whether a project wants them enforced is a house-style decision rather than a correctness one:
 
 - `-require-qt-c-receiver`: detecting `qt.Assert(t, …)` / `qt.Check(t, …)` and suggesting `c.Assert(…)` / `c.Check(…)` on a `*qt.C`
+- `-require-testing-run`: detecting `c.Run(name, func(c *qt.C))` and suggesting `t.Run(name, func(t *testing.T))` with a per-subtest `qt.New`
 
 Nothing in the default rule set changes when these flags are absent.
 
@@ -107,6 +108,7 @@ qtlint -fix -only-stable-fixes ./...
 # Enable an opt-in house-style rule (off unless asked for)
 qtlint -require-qt-c-receiver ./...
 qtlint -fix -require-qt-c-receiver ./...
+qtlint -fix -require-testing-run ./...
 ```
 
 ### With golangci-lint
@@ -133,7 +135,7 @@ Pass `-only-stable-fixes` to withhold auto-fixes for those uncertain cases. The 
 
 ## Rules
 
-Rules 1 to 11 are on by default. Rule 12 and above are **house-style rules, off by default**, and each is named after the flag that turns it on.
+Rules 1 to 11 are on by default. Rules 12 and 13 are **house-style rules, off by default**, and each is named after the flag that turns it on.
 
 All rules support **automatic fixing** with the `-fix` flag. For rules 9 and 10 the rewrite is best-effort in some variants (multi-arg `t.Fatal`, non-literal format string, `if`-init statement, spread arguments); the unsafe-by-default variants are still emitted as fixes but can be skipped with `-only-stable-fixes`. Cases that cannot be rewritten at all (init-statement and spread args) remain report-only.
 
@@ -459,6 +461,60 @@ An aliased quicktest import is matched the same way the default rules match it �
 ```
 qtlint: use c.Assert(...) instead of qt.Assert(t, ...)
 qtlint: use c.Check(...) instead of qt.Check(t, ...)
+```
+
+### 13. Require `t.Run` with a per-subtest `qt.New` — `-require-testing-run`
+
+**House-style rule, off by default.** `c.Run` is a legitimate quicktest API and some projects prefer it, so nothing below is reported unless you pass `-require-testing-run`.
+
+Projects that enforce the standard-library form do it for three reasons. The subtest signature stops being special: `t.Run(name, func(t *testing.T))` is what every Go reader and every tool already expects, so table-driven helpers and anything taking a `*testing.T` compose without a shim. Shadowing becomes visible: `c.Run(name, func(c *qt.C))` shadows the outer `c` with a different `*qt.C` of the same name and type, and a reader cannot tell from the body which one a line means. And the parent's `*qt.C` stops being reachable by accident — under `c.Run` a closure can still name the *enclosing* `c` for a `Cleanup` or a `Patch`, which binds to the parent test rather than the subtest, and that is more often a mistake than an intention.
+
+**Bad:**
+```go
+func TestExample(t *testing.T) {
+    c := qt.New(t)
+    c.Run("sub", func(c *qt.C) {
+        c.Assert(got, qt.Equals, want)
+    })
+}
+```
+
+**Good:**
+```go
+func TestExample(t *testing.T) {
+    t.Run("sub", func(t *testing.T) {
+        c := qt.New(t)
+        c.Assert(got, qt.Equals, want)
+    })
+}
+```
+
+Note that this repository's own tests are written in the target form. Enabling this rule while leaving a `c.Run` example in the project's own style guide is how the rule gets argued with six months later, so a project adopting it should update its contributor documentation at the same time — most `quicktest` examples in the wild show `c.Run`.
+
+**Auto-fix:** ✅ for every reported site, and the rewrite touches four things at once so that the result compiles:
+
+- the receiver of `.Run` becomes the `*testing.T` the `*qt.C` was made from;
+- the closure parameter becomes `t *testing.T`, keeping the original `*qt.C` identifier for the body to use;
+- `c := qt.New(t)` opens the closure — but only when the closure still needs a `*qt.C` after the rewrite. A closure whose sole use of it was the receiver of a nested `c.Run` loses that use, and a declaration with no uses does not compile;
+- the receiver's own `c := qt.New(t)` is removed when the rewrite takes its last use, for the same reason.
+
+The new parameter is named `t` unless the closure already refers to something called `t` — usually the enclosing test — in which case the next free name is used and that reference keeps meaning what it meant.
+
+**Nested subtests** are rewritten as one consistent set of edits. The inner call names the parameter the outer rewrite introduces, which is resolved before the inner one is planned; applying an outer rewrite on its own would otherwise leave an inner `c.Run` whose receiver no longer exists.
+
+**`-only-stable-fixes`** withholds the fix — the diagnostic still fires — when the closure calls `Cleanup`, `Parallel`, `Setenv`, `TempDir`, `Patch`, `Defer` or `Mkdir` on its own `*qt.C`. Those bind to whichever test the `*qt.C` came from, and the rewrite deliberately rebinds them to the subtest; a project relying on `c.Run`'s parent-scoped behavior would see a change. That is the one shape where this rewrite can alter what a test does, which is exactly what the flag is for. When a fix is withheld, so are the fixes for any subtests nested inside it, and the receiver's declaration is kept, because the withheld `c.Run` still uses it.
+
+The rule does not fire when:
+
+- **the subtest is a named function rather than a literal.** Its signature is `func(*qt.C)`, which `t.Run` will not accept; rewriting it means changing a declaration that may have callers elsewhere in the package or beyond it. That is out of scope, and since a reported site with no fix puts the work back on the author for a rewrite the tool declined to reason about, such a call is not reported at all;
+- **the receiver is not traceable to a `*testing.T`** — a `*qt.C` that arrived as a parameter, came out of a struct field or a factory, or was assigned again after `qt.New`. There is no name the rewrite could put in front of `.Run`;
+- **the file does not import `testing` under a usable name**, since the new parameter type has to name it.
+
+Both packages are resolved through the type checker, so an aliased `quicktest` or `testing` import is matched and the rewrite writes whichever names the file uses.
+
+**Error message:**
+```
+qtlint: use t.Run with a per-subtest qt.New instead of c.Run
 ```
 
 ## Examples

--- a/qtcbinding.go
+++ b/qtcbinding.go
@@ -5,12 +5,64 @@ import (
 	"go/token"
 	"go/types"
 	"strconv"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 )
 
+// quicktestPkgPath is the import path of the library whose usage this
+// analyzer enforces practices for.
+const quicktestPkgPath = "github.com/frankban/quicktest"
+
 // testingPkgPath is the import path of the standard library testing package.
 const testingPkgPath = "testing"
+
+// importedPkgName returns the name under which file imports path, or "" when
+// the file does not import it under a name a new reference could use: a blank
+// or dot import qualifies nothing.
+func importedPkgName(pass *analysis.Pass, file *ast.File, path string) string {
+	for _, imp := range file.Imports {
+		imported, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || imported != path {
+			continue
+		}
+		if imp.Name != nil {
+			if imp.Name.Name == "_" || imp.Name.Name == "." {
+				return ""
+			}
+			return imp.Name.Name
+		}
+		if obj, ok := pass.TypesInfo.Implicits[imp].(*types.PkgName); ok {
+			return obj.Name()
+		}
+	}
+	return ""
+}
+
+// enclosingFile returns the *ast.File at the root of an inspector stack.
+func enclosingFile(stack []ast.Node) *ast.File {
+	if len(stack) == 0 {
+		return nil
+	}
+	file, ok := stack[0].(*ast.File)
+	if !ok {
+		return nil
+	}
+	return file
+}
+
+// outermostFunc returns the outermost function declaration or literal on
+// stack. Every use of a variable declared inside a function lies within it,
+// so it bounds the search for the uses a rewrite would remove.
+func outermostFunc(stack []ast.Node) ast.Node {
+	for _, n := range stack {
+		switch n.(type) {
+		case *ast.FuncDecl, *ast.FuncLit:
+			return n
+		}
+	}
+	return nil
+}
 
 // isTestingTPtr reports whether typ is exactly *testing.T.
 //
@@ -62,8 +114,18 @@ func freeName(base string, taken map[string]bool) string {
 	}
 }
 
+// qtCOrigin records where a *qt.C variable came from.
+type qtCOrigin struct {
+	// arg is the expression passed to qt.New.
+	arg ast.Expr
+	// decl is the statement that declares the variable. A rewrite that
+	// removes the variable's last use has to remove this statement with it,
+	// or the result does not compile.
+	decl ast.Stmt
+}
+
 // collectQtCOrigins maps every *qt.C variable declared within root by a call
-// to qt.New to the argument of that call.
+// to qt.New to that call's argument and the declaring statement.
 //
 // Only c := qt.New(t) and var c = qt.New(t) are recognized. A *qt.C obtained
 // any other way (a parameter, a struct field, a helper's return value) has no
@@ -73,11 +135,10 @@ func freeName(base string, taken map[string]bool) string {
 // A variable that is written again after its declaration is dropped, because
 // the declaration is no longer a true statement about which test the *qt.C
 // holds. See invalidateRebound.
-func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.Expr {
-	origins := make(map[types.Object]ast.Expr)
+func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]qtCOrigin {
+	origins := make(map[types.Object]qtCOrigin)
 
-	declaredAt := make(map[types.Object]ast.Node)
-	record := func(name, value ast.Expr, decl ast.Node) {
+	record := func(name, value ast.Expr, decl ast.Stmt) {
 		ident, ok := name.(*ast.Ident)
 		if !ok {
 			return
@@ -87,8 +148,7 @@ func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.
 			return
 		}
 		if arg, ok := qtNewArg(pass, value); ok {
-			origins[obj] = arg
-			declaredAt[obj] = decl
+			origins[obj] = qtCOrigin{arg: arg, decl: decl}
 		}
 	}
 
@@ -104,7 +164,7 @@ func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.
 		return true
 	})
 
-	invalidateRebound(pass, root, origins, declaredAt)
+	invalidateRebound(pass, root, origins)
 
 	return origins
 }
@@ -118,13 +178,8 @@ func collectQtCOrigins(pass *analysis.Pass, root ast.Node) map[types.Object]ast.
 // onto a different test — silently, since both spellings compile. Taking the
 // variable's address puts the same write out of reach of this analysis, so it
 // is treated the same way.
-func invalidateRebound(
-	pass *analysis.Pass,
-	root ast.Node,
-	origins map[types.Object]ast.Expr,
-	declaredAt map[types.Object]ast.Node,
-) {
-	drop := func(expr ast.Expr, at ast.Node) {
+func invalidateRebound(pass *analysis.Pass, root ast.Node, origins map[types.Object]qtCOrigin) {
+	drop := func(expr ast.Expr, at ast.Stmt) {
 		ident, ok := stripParens(expr).(*ast.Ident)
 		if !ok {
 			return
@@ -133,7 +188,7 @@ func invalidateRebound(
 		if obj == nil {
 			obj = pass.TypesInfo.Defs[ident]
 		}
-		if _, ok := origins[obj]; ok && declaredAt[obj] != at {
+		if origin, ok := origins[obj]; ok && origin.decl != at {
 			delete(origins, obj)
 		}
 	}
@@ -158,18 +213,16 @@ func invalidateRebound(
 
 // collectQtCVarSpecs feeds every single-name, single-value var specification
 // in stmt to record.
-func collectQtCVarSpecs(stmt *ast.DeclStmt, record func(name, value ast.Expr, decl ast.Node)) {
+func collectQtCVarSpecs(stmt *ast.DeclStmt, record func(name, value ast.Expr, decl ast.Stmt)) {
 	decl, ok := stmt.Decl.(*ast.GenDecl)
-	if !ok || decl.Tok != token.VAR {
+	if !ok || decl.Tok != token.VAR || len(decl.Specs) != 1 {
 		return
 	}
-	for _, spec := range decl.Specs {
-		vs, ok := spec.(*ast.ValueSpec)
-		if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
-			continue
-		}
-		record(vs.Names[0], vs.Values[0], stmt)
+	vs, ok := decl.Specs[0].(*ast.ValueSpec)
+	if !ok || len(vs.Names) != 1 || len(vs.Values) != 1 {
+		return
 	}
+	record(vs.Names[0], vs.Values[0], stmt)
 }
 
 // qtNewArg returns the sole argument of a call to quicktest's New function.
@@ -231,9 +284,72 @@ func enclosingBinder(pass *analysis.Pass, stack []ast.Node, obj types.Object) (a
 }
 
 // prependStmtEdit returns the edit that makes code the first statement of
-// body. The inserted text carries no indentation: every driver that applies a
+// body.
+//
+// Where the body's first statement already has a line to itself, the new
+// statement takes a line above it. Inserting straight after the brace also
+// works, but gofmt then pulls any trailing comment from the brace's line down
+// onto the inserted statement, so a comment written about a subtest ends up
+// reading as a comment about the qt.New that opens it.
+//
+// The inserted text carries no indentation: every driver that applies a
 // SuggestedFix reformats the file afterwards.
-func prependStmtEdit(body *ast.BlockStmt, code string) analysis.TextEdit {
+func prependStmtEdit(pass *analysis.Pass, body *ast.BlockStmt, code string) analysis.TextEdit {
+	if at, ok := firstStmtLineStart(pass, body); ok {
+		return analysis.TextEdit{Pos: at, End: at, NewText: []byte(code + "\n")}
+	}
 	at := body.Lbrace + 1
 	return analysis.TextEdit{Pos: at, End: at, NewText: []byte("\n" + code)}
+}
+
+// firstStmtLineStart returns the start of the line holding body's first
+// statement, and reports false when that statement shares its line with the
+// opening brace — inserting at the line start would then put the new
+// statement after it.
+func firstStmtLineStart(pass *analysis.Pass, body *ast.BlockStmt) (token.Pos, bool) {
+	if len(body.List) == 0 {
+		return token.NoPos, false
+	}
+	file := pass.Fset.File(body.Lbrace)
+	if file == nil {
+		return token.NoPos, false
+	}
+	first := file.Line(body.List[0].Pos())
+	if first <= file.Line(body.Lbrace) {
+		return token.NoPos, false
+	}
+	return file.LineStart(first), true
+}
+
+// wholeLineSpan returns the span covering every line node occupies, including
+// the final newline, and reports whether node is the only thing on them.
+//
+// Callers use it to delete a declaration a rewrite left unused. Deleting only
+// the node's own span would leave a blank line behind; deleting the whole
+// line when the node shares it with other code would take that code too, so
+// ok is false in that case and the caller must decline the rewrite.
+func wholeLineSpan(pass *analysis.Pass, node ast.Node) (start, end token.Pos, ok bool) {
+	file := pass.Fset.File(node.Pos())
+	if file == nil {
+		return token.NoPos, token.NoPos, false
+	}
+	content, err := pass.ReadFile(file.Name())
+	if err != nil || len(content) != file.Size() {
+		return token.NoPos, token.NoPos, false
+	}
+
+	lineStart := file.LineStart(file.Line(node.Pos()))
+	if strings.TrimSpace(string(content[file.Offset(lineStart):file.Offset(node.Pos())])) != "" {
+		return token.NoPos, token.NoPos, false
+	}
+
+	lineEnd := token.Pos(file.Base() + file.Size())
+	if endLine := file.Line(node.End()); endLine < file.LineCount() {
+		lineEnd = file.LineStart(endLine + 1)
+	}
+	if strings.TrimSpace(string(content[file.Offset(node.End()):file.Offset(lineEnd)])) != "" {
+		return token.NoPos, token.NoPos, false
+	}
+
+	return lineStart, lineEnd, true
 }

--- a/qtlint.go
+++ b/qtlint.go
@@ -28,6 +28,8 @@
 // because both forms they choose between are correct quicktest:
 //   - -require-qt-c-receiver: qt.Assert(t, ...) / qt.Check(t, ...) which
 //     should be replaced with c.Assert(...) / c.Check(...) on a *qt.C
+//   - -require-testing-run: c.Run(name, func(c *qt.C)) which should be
+//     replaced with t.Run(name, func(t *testing.T)) plus a per-subtest qt.New
 //
 // This linter is designed to be used as a custom linter for golangci-lint.
 package qtlint
@@ -61,6 +63,12 @@ type analyzer struct {
 	// qt.Assert(t, …) / qt.Check(t, …) form. It is off by default: both forms
 	// are correct quicktest, and which one a project wants is a style choice.
 	requireQtCReceiver bool
+
+	// requireTestingRun enables the opt-in house-style rule that requires
+	// subtests to be written as t.Run(name, func(t *testing.T)) with a
+	// per-subtest qt.New rather than as c.Run. It is off by default: c.Run is
+	// a legitimate quicktest API and some projects prefer it.
+	requireTestingRun bool
 }
 
 // NewAnalyzer creates a new instance of the qtlint analyzer.
@@ -79,6 +87,9 @@ func NewAnalyzer() *analysis.Analyzer {
 	aa.Flags.BoolVar(&a.requireQtCReceiver, "require-qt-c-receiver", false,
 		"house-style rule, off by default: report qt.Assert(t, ...) and "+
 			"qt.Check(t, ...) and suggest the *qt.C method form")
+	aa.Flags.BoolVar(&a.requireTestingRun, "require-testing-run", false,
+		"house-style rule, off by default: report c.Run(...) subtests and "+
+			"suggest t.Run(name, func(t *testing.T)) with a per-subtest qt.New")
 	return aa
 }
 
@@ -127,7 +138,7 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 // They need the enclosing function to decide where a *qt.C would be created,
 // which Preorder does not provide, so they get their own WithStack traversal.
 func (a *analyzer) runOptInRules(pass *analysis.Pass, insp *inspector.Inspector) {
-	if !a.requireQtCReceiver {
+	if !a.requireQtCReceiver && !a.requireTestingRun {
 		return
 	}
 
@@ -145,6 +156,9 @@ func (a *analyzer) runOptInRules(pass *analysis.Pass, insp *inspector.Inspector)
 		}
 		if a.requireQtCReceiver {
 			checkRequireQtCReceiver(pass, stack, call)
+		}
+		if a.requireTestingRun {
+			a.checkRequireTestingRun(pass, stack, call)
 		}
 		return true
 	})
@@ -384,7 +398,7 @@ func isPackageQualified(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
 		return false
 	}
 
-	return pkg.Imported().Path() == "github.com/frankban/quicktest"
+	return pkg.Imported().Path() == quicktestPkgPath
 }
 
 // isQuicktestCMethod checks if a selector is a method on *qt.C.
@@ -410,7 +424,7 @@ func isQuicktestCMethod(pass *analysis.Pass, sel *ast.SelectorExpr) bool {
 		return false
 	}
 
-	return obj.Pkg().Path() == "github.com/frankban/quicktest" && obj.Name() == "C"
+	return obj.Pkg().Path() == quicktestPkgPath && obj.Name() == "C"
 }
 
 // hasLenCheckerInfo holds the resolved information for a HasLen checker replacement.
@@ -1124,7 +1138,7 @@ func findQuicktestPkgAlias(pass *analysis.Pass, start ast.Node) string {
 			if !ok {
 				continue
 			}
-			if pkgName.Imported().Path() == "github.com/frankban/quicktest" {
+			if pkgName.Imported().Path() == quicktestPkgPath {
 				return name
 			}
 		}
@@ -1148,7 +1162,7 @@ func isQuicktestCType(t types.Type) bool {
 	if obj == nil || obj.Pkg() == nil {
 		return false
 	}
-	return obj.Pkg().Path() == "github.com/frankban/quicktest" && obj.Name() == "C"
+	return obj.Pkg().Path() == quicktestPkgPath && obj.Name() == "C"
 }
 
 func findQuicktestCVarName(pass *analysis.Pass, start ast.Node) string {

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -55,4 +55,26 @@ func TestFixes(t *testing.T) {
 		setFlag(t, analyzer, "require-qt-c-receiver")
 		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "qtcreceiveralias")
 	})
+
+	t.Run("testingrunfix", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-testing-run")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "testingrunfix")
+	})
+
+	t.Run("testingrunalias", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-testing-run")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "testingrunalias")
+	})
+
+	// With --only-stable-fixes: a closure using a test-scoped *qt.C method
+	// keeps its diagnostic and loses its fix, and the receiver it shares with
+	// a rewritten sibling keeps its declaration.
+	t.Run("testingrun only-stable-fixes", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-testing-run")
+		setFlag(t, analyzer, "only-stable-fixes")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "testingrunonlystable")
+	})
 }

--- a/qtlint_test.go
+++ b/qtlint_test.go
@@ -84,6 +84,17 @@ func TestAnalyzer(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		analysistest.Run(t, testdata, analyzer, "qtcreceiveroff")
 	})
+
+	t.Run("require-testing-run patterns", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-testing-run")
+		analysistest.Run(t, testdata, analyzer, "testingrun")
+	})
+
+	t.Run("require-testing-run is off by default", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		analysistest.Run(t, testdata, analyzer, "testingrunoff")
+	})
 }
 
 // setFlag enables a boolean analyzer flag, failing the test if the flag does

--- a/requireqtcreceiver.go
+++ b/requireqtcreceiver.go
@@ -99,7 +99,7 @@ func checkRequireQtCReceiver(pass *analysis.Pass, stack []ast.Node, call *ast.Ca
 		// The name is taken from the whole function, not just its body: a
 		// receiver, parameter or named result shares the body's scope.
 		cName = freeName("c", identNamesIn(binder))
-		edits = append(edits, prependStmtEdit(body,
+		edits = append(edits, prependStmtEdit(pass, body,
 			fmt.Sprintf("%s := %s.New(%s)", cName, m.qtAlias, m.tIdent.Name)))
 	}
 
@@ -143,8 +143,8 @@ func visibleQtCFrom(pass *analysis.Pass, body *ast.BlockStmt, tObj types.Object,
 	}
 
 	var best types.Object
-	for obj, arg := range collectQtCOrigins(pass, body) {
-		ident, ok := arg.(*ast.Ident)
+	for obj, origin := range collectQtCOrigins(pass, body) {
+		ident, ok := origin.arg.(*ast.Ident)
 		if !ok || pass.TypesInfo.Uses[ident] != tObj {
 			continue
 		}

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -1,0 +1,360 @@
+package qtlint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// testScopedCMethods are the *qt.C methods that act on the test the *qt.C was
+// made from rather than on the assertion at hand.
+//
+// Under c.Run they bind to whichever test the receiver came from; after the
+// rewrite the closure's *qt.C is made from the subtest, which is what a
+// reader almost always meant. "Almost always" is the whole reason
+// -only-stable-fixes exists, so a closure that calls one of these keeps its
+// diagnostic but loses its automatic fix under that flag.
+var testScopedCMethods = map[string]bool{
+	"Cleanup":  true,
+	"Defer":    true,
+	"Mkdir":    true,
+	"Parallel": true,
+	"Patch":    true,
+	"Setenv":   true,
+	"TempDir":  true,
+}
+
+// qtCRun describes a c.Run(name, func(c *qt.C) { … }) call.
+type qtCRun struct {
+	// sel is the call's "c.Run" selector.
+	sel *ast.SelectorExpr
+	// recv is the receiver identifier and recvObj the object it refers to.
+	recv    *ast.Ident
+	recvObj types.Object
+	// lit is the subtest closure and param its sole *qt.C parameter.
+	lit   *ast.FuncLit
+	param *ast.Field
+	// cName is the parameter's name and cObj the object it declares. Both
+	// are zero when the parameter is unnamed or blank.
+	cName string
+	cObj  types.Object
+}
+
+// matchQtCRun parses call into a qtCRun.
+//
+// The receiver is matched on its type, so an identifier other than c is
+// matched just the same. The subtest argument must be a function literal:
+// issue #42's case 5, a named function, has signature func(*qt.C), which
+// t.Run will not accept, and rewriting it means changing a declaration that
+// may have callers elsewhere. That is out of scope, and since a reported site
+// without a fix is a site whose repair falls back on the author, such a call
+// is not reported at all.
+func matchQtCRun(pass *analysis.Pass, call *ast.CallExpr) (qtCRun, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Run" || !isQuicktestCMethod(pass, sel) {
+		return qtCRun{}, false
+	}
+	if len(call.Args) != 2 {
+		return qtCRun{}, false
+	}
+	recv, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return qtCRun{}, false
+	}
+	recvObj := pass.TypesInfo.Uses[recv]
+	if recvObj == nil {
+		return qtCRun{}, false
+	}
+	lit, ok := call.Args[1].(*ast.FuncLit)
+	if !ok {
+		return qtCRun{}, false
+	}
+	params := lit.Type.Params
+	if params == nil || len(params.List) != 1 {
+		return qtCRun{}, false
+	}
+	param := params.List[0]
+	if len(param.Names) > 1 || !isQuicktestCType(pass.TypesInfo.TypeOf(param.Type)) {
+		return qtCRun{}, false
+	}
+
+	run := qtCRun{sel: sel, recv: recv, recvObj: recvObj, lit: lit, param: param}
+	if len(param.Names) == 1 && param.Names[0].Name != "_" {
+		run.cName = param.Names[0].Name
+		run.cObj = pass.TypesInfo.Defs[param.Names[0]]
+	}
+	return run, true
+}
+
+// checkRequireTestingRun reports a c.Run subtest and suggests the
+// t.Run(name, func(t *testing.T) { c := qt.New(t) }) form.
+func (a *analyzer) checkRequireTestingRun(pass *analysis.Pass, stack []ast.Node, call *ast.CallExpr) {
+	run, ok := matchQtCRun(pass, call)
+	if !ok {
+		return
+	}
+
+	file := enclosingFile(stack)
+	if file == nil {
+		return
+	}
+	qtAlias := importedPkgName(pass, file, quicktestPkgPath)
+	testingName := importedPkgName(pass, file, testingPkgPath)
+	if qtAlias == "" || testingName == "" {
+		return
+	}
+
+	target, ok := a.resolveRunTarget(pass, stack, run, qtAlias, testingName)
+	if !ok {
+		return
+	}
+
+	// The receiver may have had no other use, in which case its declaration
+	// goes with the rewrite.
+	edits, ok := a.unusedReceiverDeclEdits(pass, stack, run)
+	if !ok {
+		return
+	}
+
+	tName := freeName("t", takenNames(run.lit, qtAlias, testingName))
+	edits = append(edits,
+		analysis.TextEdit{
+			Pos:     run.sel.X.Pos(),
+			End:     run.sel.X.End(),
+			NewText: []byte(target.recv),
+		},
+		analysis.TextEdit{
+			Pos:     run.param.Pos(),
+			End:     run.param.End(),
+			NewText: []byte(newRunParam(run, tName, testingName)),
+		},
+	)
+
+	// The *qt.C is recreated only if the closure still needs one. A closure
+	// whose only use of it was the receiver of a nested c.Run loses that use
+	// to the nested rewrite, and a declaration with no uses does not compile.
+	if run.cObj != nil && a.survivingUses(pass, run.lit, run.cObj) > 0 {
+		edits = append(edits, prependStmtEdit(pass, run.lit.Body,
+			fmt.Sprintf("%s := %s.New(%s)", run.cName, qtAlias, tName)))
+	}
+
+	diag := analysis.Diagnostic{
+		Pos:     call.Fun.Pos(),
+		End:     call.Fun.End(),
+		Message: "qtlint: use t.Run with a per-subtest qt.New instead of c.Run",
+	}
+	unstable := target.unstable || closureUsesTestScopedMethod(pass, run)
+	if !unstable || !a.onlyStableFixes {
+		diag.SuggestedFixes = []analysis.SuggestedFix{{
+			Message:   "Replace c.Run with t.Run and a per-subtest qt.New",
+			TextEdits: edits,
+		}}
+	}
+	pass.Report(diag)
+}
+
+// runTarget is what a c.Run receiver rewrites to.
+type runTarget struct {
+	// recv is the *testing.T expression that replaces the receiver.
+	recv string
+	// unstable reports that an enclosing rewrite may change behavior. It
+	// travels inward: a nested rewrite that lands while its parent is
+	// withheld names a t that the parent has not created yet.
+	unstable bool
+}
+
+// resolveRunTarget works out what the receiver of run's Run call becomes.
+//
+// Two shapes reach a *testing.T. The receiver may be the *qt.C parameter of
+// an enclosing c.Run closure that this rule also rewrites, in which case it
+// becomes the parameter that rewrite gives that closure; or it may be a
+// variable declared as c := qt.New(t), in which case it becomes that t.
+// Anything else — a *qt.C parameter of a helper, a struct field, a value from
+// a factory — has no statically known *testing.T, so the rule leaves it be.
+func (a *analyzer) resolveRunTarget(
+	pass *analysis.Pass,
+	stack []ast.Node,
+	run qtCRun,
+	qtAlias, testingName string,
+) (runTarget, bool) {
+	if target, ok := a.targetFromEnclosingRun(pass, stack, run, qtAlias, testingName); ok {
+		return target, true
+	}
+	return targetFromQtNew(pass, stack, run)
+}
+
+// targetFromEnclosingRun handles a receiver that is the *qt.C parameter of an
+// enclosing c.Run closure. Resolving the enclosing rewrite first is what
+// makes a nest come out right: the inner call names the parameter the outer
+// rewrite introduces, so the whole nest is planned innermost-last and lands
+// as one consistent set of edits.
+func (a *analyzer) targetFromEnclosingRun(
+	pass *analysis.Pass,
+	stack []ast.Node,
+	run qtCRun,
+	qtAlias, testingName string,
+) (runTarget, bool) {
+	for i := len(stack) - 1; i > 0; i-- {
+		lit, ok := stack[i].(*ast.FuncLit)
+		if !ok {
+			continue
+		}
+		outerCall, ok := stack[i-1].(*ast.CallExpr)
+		if !ok {
+			continue
+		}
+		outer, ok := matchQtCRun(pass, outerCall)
+		if !ok || outer.lit != lit || outer.cObj == nil || outer.cObj != run.recvObj {
+			continue
+		}
+		outerTarget, ok := a.resolveRunTarget(pass, stack[:i], outer, qtAlias, testingName)
+		if !ok {
+			return runTarget{}, false
+		}
+		return runTarget{
+			recv:     freeName("t", takenNames(outer.lit, qtAlias, testingName)),
+			unstable: outerTarget.unstable || closureUsesTestScopedMethod(pass, outer),
+		}, true
+	}
+	return runTarget{}, false
+}
+
+// targetFromQtNew handles a receiver declared as c := qt.New(t).
+func targetFromQtNew(pass *analysis.Pass, stack []ast.Node, run qtCRun) (runTarget, bool) {
+	root := outermostFunc(stack)
+	if root == nil {
+		return runTarget{}, false
+	}
+	origin, ok := collectQtCOrigins(pass, root)[run.recvObj]
+	if !ok {
+		return runTarget{}, false
+	}
+	tIdent, ok := origin.arg.(*ast.Ident)
+	if !ok {
+		return runTarget{}, false
+	}
+	tObj := pass.TypesInfo.Uses[tIdent]
+	if tObj == nil || !isTestingTPtr(tObj.Type()) {
+		return runTarget{}, false
+	}
+
+	// The name has to still mean that object where the rewrite writes it.
+	scope := pass.Pkg.Scope().Innermost(run.sel.Pos())
+	if scope == nil {
+		return runTarget{}, false
+	}
+	if _, found := scope.LookupParent(tIdent.Name, run.sel.Pos()); found != tObj {
+		return runTarget{}, false
+	}
+	return runTarget{recv: tIdent.Name}, true
+}
+
+// unusedReceiverDeclEdits returns the edits that remove the receiver's
+// declaration when the rewrite takes its last use, and no edits when it does
+// not.
+//
+// It reports false when the declaration has to go but cannot be removed
+// cleanly, because there is then no correct fix. The caller declines to
+// report at all rather than offer one that does not compile.
+func (a *analyzer) unusedReceiverDeclEdits(pass *analysis.Pass, stack []ast.Node, run qtCRun) ([]analysis.TextEdit, bool) {
+	root := outermostFunc(stack)
+	if root == nil {
+		return nil, true
+	}
+	origin, ok := collectQtCOrigins(pass, root)[run.recvObj]
+	if !ok || a.survivingUses(pass, root, run.recvObj) > 0 {
+		return nil, true
+	}
+	start, end, ok := wholeLineSpan(pass, origin.decl)
+	if !ok {
+		return nil, false
+	}
+	return []analysis.TextEdit{{Pos: start, End: end}}, true
+}
+
+// survivingUses counts the references to obj within root that the rewrite
+// leaves behind.
+//
+// A reference disappears when it is the receiver of a c.Run this rule
+// rewrites. Under -only-stable-fixes a call whose closure uses a test-scoped
+// *qt.C method keeps its fix withheld, so its receiver survives and the
+// declaration must stay.
+func (a *analyzer) survivingUses(pass *analysis.Pass, root ast.Node, obj types.Object) int {
+	rewritten := make(map[*ast.Ident]bool)
+	ast.Inspect(root, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		run, ok := matchQtCRun(pass, call)
+		if !ok || run.recvObj != obj {
+			return true
+		}
+		if a.onlyStableFixes && closureUsesTestScopedMethod(pass, run) {
+			return true
+		}
+		rewritten[run.recv] = true
+		return true
+	})
+
+	var count int
+	ast.Inspect(root, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if ok && pass.TypesInfo.Uses[ident] == obj && !rewritten[ident] {
+			count++
+		}
+		return true
+	})
+	return count
+}
+
+// closureUsesTestScopedMethod reports whether run's closure calls one of the
+// *qt.C methods that bind to a test rather than to an assertion, on its own
+// parameter.
+func closureUsesTestScopedMethod(pass *analysis.Pass, run qtCRun) bool {
+	if run.cObj == nil {
+		return false
+	}
+	var found bool
+	ast.Inspect(run.lit, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || !testScopedCMethods[sel.Sel.Name] {
+			return true
+		}
+		if ident, ok := sel.X.(*ast.Ident); ok && pass.TypesInfo.Uses[ident] == run.cObj {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// newRunParam renders the closure's rewritten parameter, keeping the shape
+// the author chose: an unnamed or blank *qt.C stays unnamed or blank, because
+// nothing in the rewritten body would refer to it.
+func newRunParam(run qtCRun, tName, testingName string) string {
+	typeText := "*" + testingName + ".T"
+	switch {
+	case run.cName != "":
+		return tName + " " + typeText
+	case len(run.param.Names) == 1:
+		return "_ " + typeText
+	default:
+		return typeText
+	}
+}
+
+// takenNames returns every identifier appearing within lit, plus extra names
+// the rewrite writes and must therefore not shadow.
+func takenNames(lit *ast.FuncLit, extra ...string) map[string]bool {
+	names := identNamesIn(lit)
+	for _, name := range extra {
+		names[name] = true
+	}
+	return names
+}

--- a/testdata/src/github.com/frankban/quicktest/quicktest.go
+++ b/testdata/src/github.com/frankban/quicktest/quicktest.go
@@ -29,6 +29,31 @@ func (c *C) Run(name string, f func(c *C)) bool {
 	return true
 }
 
+// Cleanup registers f to be called when the test is done.
+func (c *C) Cleanup(f func()) {}
+
+// Defer registers f to be called when the test's Done method is called.
+func (c *C) Defer(f func()) {}
+
+// Mkdir creates a directory that is removed when the test is done.
+func (c *C) Mkdir(name string) string {
+	return name
+}
+
+// Parallel signals that the test is to be run in parallel.
+func (c *C) Parallel() {}
+
+// Patch sets a variable to a temporary value for the duration of the test.
+func (c *C) Patch(dest, value any) {}
+
+// Setenv sets an environment variable for the duration of the test.
+func (c *C) Setenv(key, value string) {}
+
+// TempDir returns a temporary directory removed when the test is done.
+func (c *C) TempDir() string {
+	return ""
+}
+
 // Assert runs the given check using the provided t and stops execution in case of failure.
 func Assert(t testing.TB, got interface{}, checker Checker, args ...interface{}) bool {
 	return true

--- a/testdata/src/testingrun/testingrun.go
+++ b/testdata/src/testingrun/testingrun.go
@@ -1,0 +1,102 @@
+package testingrun
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The plain shape. c.Run was the receiver's only use, so its declaration goes
+// with the rewrite.
+func TestPlain(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// The receiver survives when the test still uses it for something else.
+func TestReceiverSurvives(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// The receiver is matched on its type, not on the identifier c, and so is the
+// closure's parameter.
+func TestOtherName(t *testing.T) {
+	qc := qt.New(t)
+	qc.Run("sub", func(inner *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		inner.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Nested subtests. The inner rewrite names the parameter the outer rewrite
+// introduces, so the two land as one consistent set of edits.
+func TestNested(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
+// The closure already refers to the enclosing test's t, so the new parameter
+// takes a different name and that reference keeps meaning the parent.
+func TestOuterTReferenced(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("parent")
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// A blank parameter stays blank: nothing in the rewritten body could name it.
+func TestBlankParam(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(_ *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("sub")
+	})
+}
+
+// A closure calling a test-scoped *qt.C method is reported and still fixed by
+// default; only -only-stable-fixes withholds it.
+func TestTestScopedMethod(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Cleanup(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Not reported: the subtest is a named function, whose func(*qt.C) signature
+// t.Run will not take. Rewriting it means changing a declaration that may
+// have callers elsewhere, so it is out of scope.
+func namedSubtest(c *qt.C) {
+	c.Assert(1, qt.Equals, 1)
+}
+
+func TestNamedFunc(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", namedSubtest)
+}
+
+// Not reported: the *qt.C arrived as a parameter, so there is no statically
+// known *testing.T to name.
+func helper(c *qt.C) {
+	c.Run("sub", func(c *qt.C) {
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Not reported: already the target form.
+func TestAlreadyTestingRun(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/testingrunalias/testingrunalias.go
+++ b/testdata/src/testingrunalias/testingrunalias.go
@@ -1,0 +1,17 @@
+package testingrunalias
+
+import (
+	tst "testing"
+
+	myqt "github.com/frankban/quicktest"
+)
+
+// The rule resolves both packages through the type checker, so an alias other
+// than qt is matched, and the rewrite writes whichever names the file uses —
+// including for the testing package, which the parameter type has to name.
+func TestAlias(t *tst.T) {
+	c := myqt.New(t)
+	c.Run("sub", func(c *myqt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, myqt.Equals, 1)
+	})
+}

--- a/testdata/src/testingrunalias/testingrunalias.go.golden
+++ b/testdata/src/testingrunalias/testingrunalias.go.golden
@@ -1,0 +1,18 @@
+package testingrunalias
+
+import (
+	tst "testing"
+
+	myqt "github.com/frankban/quicktest"
+)
+
+// The rule resolves both packages through the type checker, so an alias other
+// than qt is matched, and the rewrite writes whichever names the file uses —
+// including for the testing package, which the parameter type has to name.
+func TestAlias(t *tst.T) {
+	t.Run("sub", func(t *tst.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := myqt.New(t)
+		c.Assert(1, myqt.Equals, 1)
+	})
+}
+

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -1,0 +1,99 @@
+package testingrunfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The plain shape. c.Run was the receiver's only use, so its declaration goes
+// with the rewrite; leaving it behind would not compile.
+func TestPlain(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// The receiver survives when the test still uses it for something else.
+func TestReceiverSurvives(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Two subtests on one receiver: the declaration goes only once, and the
+// rewrite of each is independent of the other.
+func TestTwoSubtests(t *testing.T) {
+	c := qt.New(t)
+	c.Run("first", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+	c.Run("second", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(2, qt.Equals, 2)
+	})
+}
+
+// The receiver and the closure parameter are matched on their type, not on
+// the identifier c.
+func TestOtherName(t *testing.T) {
+	qc := qt.New(t)
+	qc.Run("sub", func(inner *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		inner.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Nested subtests. The inner rewrite names the parameter the outer rewrite
+// introduces, and the outer closure gets no qt.New because its only use of
+// the *qt.C was the receiver the inner rewrite consumes.
+func TestNested(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
+// Nested subtests where the outer closure asserts as well: it keeps its own
+// qt.New, because that use survives the inner rewrite.
+func TestNestedOuterAsserts(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(0, qt.Equals, 0)
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
+// The closure already refers to the enclosing test's t, so the new parameter
+// takes a different name and that reference keeps meaning the parent.
+func TestOuterTReferenced(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("parent")
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// A blank parameter stays blank: nothing in the rewritten body could name it.
+func TestBlankParam(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(_ *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("sub")
+	})
+}
+
+// A closure calling a test-scoped *qt.C method is fixed by default. Only
+// -only-stable-fixes withholds it; see the testingrunonlystable package.
+func TestTestScopedMethod(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Cleanup(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -70,6 +70,20 @@ func TestNestedOuterAsserts(t *testing.T) {
 	})
 }
 
+// Nested subtests where the outer closure names the enclosing t, so the outer
+// rewrite has to take a different parameter name. The inner call must use
+// that name: using the enclosing t instead would still compile and would
+// attach the inner subtest to the parent test rather than to "outer".
+func TestNestedRenamedOuter(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("parent")
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
 // The closure already refers to the enclosing test's t, so the new parameter
 // takes a different name and that reference keeps meaning the parent.
 func TestOuterTReferenced(t *testing.T) {

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -1,0 +1,102 @@
+package testingrunfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The plain shape. c.Run was the receiver's only use, so its declaration goes
+// with the rewrite; leaving it behind would not compile.
+func TestPlain(t *testing.T) {
+	t.Run("sub", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// The receiver survives when the test still uses it for something else.
+func TestReceiverSurvives(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	t.Run("sub", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Two subtests on one receiver: the declaration goes only once, and the
+// rewrite of each is independent of the other.
+func TestTwoSubtests(t *testing.T) {
+	t.Run("first", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+	t.Run("second", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(2, qt.Equals, 2)
+	})
+}
+
+// The receiver and the closure parameter are matched on their type, not on
+// the identifier c.
+func TestOtherName(t *testing.T) {
+	t.Run("sub", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		inner := qt.New(t)
+		inner.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Nested subtests. The inner rewrite names the parameter the outer rewrite
+// introduces, and the outer closure gets no qt.New because its only use of
+// the *qt.C was the receiver the inner rewrite consumes.
+func TestNested(t *testing.T) {
+	t.Run("outer", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Run("inner", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c := qt.New(t)
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
+// Nested subtests where the outer closure asserts as well: it keeps its own
+// qt.New, because that use survives the inner rewrite.
+func TestNestedOuterAsserts(t *testing.T) {
+	t.Run("outer", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(0, qt.Equals, 0)
+		t.Run("inner", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c := qt.New(t)
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
+// The closure already refers to the enclosing test's t, so the new parameter
+// takes a different name and that reference keeps meaning the parent.
+func TestOuterTReferenced(t *testing.T) {
+	t.Run("sub", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t2)
+		t.Log("parent")
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// A blank parameter stays blank: nothing in the rewritten body could name it.
+func TestBlankParam(t *testing.T) {
+	t.Run("sub", func(_ *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("sub")
+	})
+}
+
+// A closure calling a test-scoped *qt.C method is fixed by default. Only
+// -only-stable-fixes withholds it; see the testingrunonlystable package.
+func TestTestScopedMethod(t *testing.T) {
+	t.Run("sub", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Cleanup(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -73,6 +73,20 @@ func TestNestedOuterAsserts(t *testing.T) {
 	})
 }
 
+// Nested subtests where the outer closure names the enclosing t, so the outer
+// rewrite has to take a different parameter name. The inner call must use
+// that name: using the enclosing t instead would still compile and would
+// attach the inner subtest to the parent test rather than to "outer".
+func TestNestedRenamedOuter(t *testing.T) {
+	t.Run("outer", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Log("parent")
+		t2.Run("inner", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c := qt.New(t)
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+
 // The closure already refers to the enclosing test's t, so the new parameter
 // takes a different name and that reference keeps meaning the parent.
 func TestOuterTReferenced(t *testing.T) {

--- a/testdata/src/testingrunoff/testingrunoff.go
+++ b/testdata/src/testingrunoff/testingrunoff.go
@@ -1,0 +1,28 @@
+package testingrunoff
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// This package is the flag gate's control. Every c.Run below is exactly what
+// -require-testing-run reports, and none of them carries a want comment: the
+// test runs it through a default analyzer, so a diagnostic here is a failure.
+// If the rule ever fires without its flag, this package goes red.
+func TestNotReportedByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) {
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+func TestNestedNotReportedByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) {
+		c.Run("inner", func(c *qt.C) {
+			c.Cleanup(func() {})
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -1,0 +1,60 @@
+package testingrunonlystable
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// A stable and an unstable subtest share one *qt.C. Under -only-stable-fixes
+// the unstable one keeps its c.Run, so the receiver still has a use and its
+// declaration must stay — deleting it here would break the file.
+func TestMixed(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("stable", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+
+	c.Run("unstable", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Cleanup(func() {})
+		c.Assert(2, qt.Equals, 2)
+	})
+}
+
+// Every method in the withheld set, one subtest each. All are reported and
+// none is rewritten under this flag.
+func TestWithheldMethods(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("parallel", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Parallel()
+	})
+	c.Run("setenv", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Setenv("K", "V")
+	})
+	c.Run("tempdir", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(c.TempDir(), qt.Not(qt.Equals), "")
+	})
+	c.Run("patch", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Patch(nil, nil)
+	})
+	c.Run("defer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Defer(func() {})
+	})
+	c.Run("mkdir", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(c.Mkdir("d"), qt.Equals, "d")
+	})
+}
+
+// An unstable outer withholds its fix, and the nested subtest withholds with
+// it: rewriting the inner alone would name a t the outer has not introduced.
+func TestNestedUnstableOuter(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Setenv("K", "V")
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -1,0 +1,62 @@
+package testingrunonlystable
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// A stable and an unstable subtest share one *qt.C. Under -only-stable-fixes
+// the unstable one keeps its c.Run, so the receiver still has a use and its
+// declaration must stay — deleting it here would break the file.
+func TestMixed(t *testing.T) {
+	c := qt.New(t)
+
+	t.Run("stable", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+
+	c.Run("unstable", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Cleanup(func() {})
+		c.Assert(2, qt.Equals, 2)
+	})
+}
+
+// Every method in the withheld set, one subtest each. All are reported and
+// none is rewritten under this flag.
+func TestWithheldMethods(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("parallel", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Parallel()
+	})
+	c.Run("setenv", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Setenv("K", "V")
+	})
+	c.Run("tempdir", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(c.TempDir(), qt.Not(qt.Equals), "")
+	})
+	c.Run("patch", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Patch(nil, nil)
+	})
+	c.Run("defer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Defer(func() {})
+	})
+	c.Run("mkdir", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(c.Mkdir("d"), qt.Equals, "d")
+	})
+}
+
+// An unstable outer withholds its fix, and the nested subtest withholds with
+// it: rewriting the inner alone would name a t the outer has not introduced.
+func TestNestedUnstableOuter(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Setenv("K", "V")
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}
+


### PR DESCRIPTION
Closes #42.

`-require-testing-run`, a house-style rule that is **off by default**. When enabled it reports every `c.Run(name, func(c *qt.C) { … })` whose receiver is a `*qt.C`, and suggests the standard-library subtest form with a per-subtest `qt.New`.

`c.Run` is a legitimate quicktest API and some projects prefer it, which is why this is behind a flag rather than in the default rule set.

```go
// reported
c := qt.New(t)
c.Run("sub", func(c *qt.C) {
    c.Assert(got, qt.Equals, want)
})

// suggested
t.Run("sub", func(t *testing.T) {
    c := qt.New(t)
    c.Assert(got, qt.Equals, want)
})
```

## The fix moves four things, and three of them are compile errors if you skip them

- **the receiver of `.Run`** becomes the `*testing.T` the `*qt.C` was made from;
- **the closure parameter** becomes `t *testing.T`, keeping the original `*qt.C` identifier so the body needs no edits at all;
- **`c := qt.New(t)` opens the closure** — but only where the closure still needs a `*qt.C` afterwards. A closure whose sole use of it was the receiver of a nested `c.Run` loses that use to the nested rewrite, and a declaration with no uses does not compile;
- **the receiver's own `c := qt.New(t)` is removed** where the rewrite took its last use, for the same reason.

The last two are why there is a surviving-use count rather than an always-insert and a never-delete. Both directions have a mutant below.

The new parameter is named `t` unless the closure already refers to something called `t` — normally the enclosing test — in which case the next free name is used and that reference keeps meaning the parent.

## Nesting

Resolved outermost-first so the inner call can name the parameter the outer rewrite introduces, and emitted as one merged edit set. Applying an outer rewrite alone leaves an inner `c.Run` whose receiver has been renamed out from under it; applying an inner rewrite alone binds the subtest to the parent test. Neither intermediate state is reachable because the nest is planned as a unit.

`TestNested` was not enough to prove this. There the outer closure's new parameter and the enclosing test's `t` are both spelled `t`, so an implementation that reached for the `t` that already exists produced identical bytes. `TestNestedRenamedOuter` makes the outer closure name the enclosing `t`, which forces the outer rewrite onto `t2` and leaves the inner call with two distinguishable spellings — `t2.Run`, which attaches the subtest to `"outer"`, and `t.Run`, which attaches it to the parent and still compiles:

```go
func TestNestedRenamedOuter(t *testing.T) {
	t.Run("outer", func(t2 *testing.T) {
		t.Log("parent")
		t2.Run("inner", func(t *testing.T) {
			c := qt.New(t)
			c.Assert(1, qt.Equals, 1)
		})
	})
}
```

## `-only-stable-fixes`

Withholds the fix, keeping the diagnostic, when the closure calls `Cleanup`, `Parallel`, `Setenv`, `TempDir`, `Patch`, `Defer` or `Mkdir` on its own `*qt.C`. Those bind to whichever test the `*qt.C` came from and the rewrite deliberately rebinds them to the subtest, so a project relying on `c.Run`'s parent-scoped behavior would see a change. That is the one shape where this rewrite can alter what a test does.

Two consequences that the `testingrunonlystable` golden pins:

- a withheld fix propagates to subtests **nested inside** it — rewriting an inner one alone would name a `t` the outer has not introduced;
- the receiver's declaration is **kept**, because the `c.Run` left behind still uses it. A stable and an unstable subtest sharing one `c := qt.New(t)` is in the testdata for exactly this.

## Out of scope, with the reason (issue #42, case 5)

A **named function rather than a literal** has signature `func(*qt.C)`, which `t.Run` will not accept. Rewriting it means changing a declaration that may have callers elsewhere in the package or beyond it. It is not rewritten and — since a reported site with no fix puts the repair back on the author for a rewrite the tool declined to reason about — it is not reported either. Stated in the README section and pinned by a testdata case that must produce no diagnostic.

The rule also declines when the receiver is not traceable to a `*testing.T` (a `*qt.C` that arrived as a parameter, came from a struct field or a factory, or was reassigned after `qt.New`), and when the file does not import `testing` under a usable name.

## Shared plumbing

Everything reusable from #43 is used rather than re-implemented: `isQuicktestCType`, `isPackageQualified`, `isTestingTPtr`, `collectQtCOrigins`, `freeName`, `identNamesIn`, `prependStmtEdit`. Three of them changed shape, each for a reason:

- **`collectQtCOrigins`** now returns a `qtCOrigin{arg, decl}` rather than the bare `qt.New` argument. This rule has to delete the declaring statement, not just read what it was made from.
- **`prependStmtEdit`** takes the `*analysis.Pass` and opens a line above the body's first statement instead of inserting straight after the brace. gofmt otherwise pulls a trailing comment down from the brace's line onto the inserted statement, so a comment written about a subtest came out reading as a comment about its `qt.New` — which, for this rule, is every rewritten site. Rule 12's goldens are unchanged by it, because its insertions go into functions whose brace line carries no comment.
- **`invalidateRebound`**, added in #44, is what makes "the receiver was reassigned after `qt.New`" a decline here too. Same helper, same bug class, both rules.

New shared helpers: `importedPkgName`, `enclosingFile`, `outermostFunc`, `wholeLineSpan`.

## Default rule set

Unchanged, measured rather than asserted. With both flags absent the analyzer does not run the opt-in traversal at all. The binary built from this branch, run with no flags over a frozen copy of the pre-change corpus, is byte-identical to the `cd48a66` baseline:

```
$ cmp corpus-baseline.txt corpus-final42.txt   # exit 0
```

Not vacuous: the same binary with `-require-testing-run` on the same corpus reports one additional diagnostic, at `b/b.go:18` — the corpus's one `c.Run`.

## Testdata

| package | what it pins |
| --- | --- |
| `testingrun` | every firing shape plus the four that must **not** fire: a named function, a `*qt.C` that arrived as a parameter, and code already in the target form |
| `testingrunfix` | the same fixable shapes with a golden — plain, receiver-survives, two siblings, a receiver not named `c`, two nesting cases, the renamed-outer nest, an outer-`t` reference, a blank parameter, and a test-scoped method fixed by default |
| `testingrunalias` | `myqt` **and** `tst "testing"` — the parameter type has to name the testing package, so both aliases matter here |
| `testingrunonlystable` | all seven withheld methods, a stable and an unstable subtest sharing one receiver, and an unstable outer with a nested inner |
| `testingrunoff` | the flag gate's control: the exact calls the rule reports, with no `want` comments, through a default analyzer |

`TestGoldenFilesCompile` (added in #43) is what proves each golden builds — the property a fix-emitting linter cannot get wrong.

## Mutants

Each is the cheaper wrong implementation, compiling, applied and reverted.

| mutant | RED | stayed green |
| --- | --- | --- |
| the flag gate ignored | `require-testing-run is off by default` (3 diagnostics) and `method_calls` (1, at `b/b.go:18`); `cmp` against the baseline corpus fails at char 4121 | every other `TestAnalyzer` subtest and **all eight** `TestFixes` subtests — the gate is orthogonal to the rewrite |
| the inner call names the `t` that exists today (`recv: outerTarget.recv`) instead of the one the outer rewrite introduces | `TestFixes/testingrunfix`, and only at `TestNestedRenamedOuter`: `t.Run("inner", …)` where `t2.Run("inner", …)` is correct | everything else, **including `TestNested`** — which is the point: without the renamed-outer fixture this mutant survives, because there both spellings are the same three characters |
| always insert `c := qt.New(t)` | `TestFixes/testingrunfix` at `TestNested` — an unused `c` in the outer closure | every `TestAnalyzer` subtest, `testingrunalias`, `testingrunonlystable` |
| never remove the receiver's declaration | `TestFixes/testingrunfix` and `/testingrunalias` — a leftover `c := qt.New(t)` with no uses | every `TestAnalyzer` subtest and `testingrunonlystable`, where the declaration is correctly kept anyway |
| `-only-stable-fixes` ignores the test-scoped methods | `TestFixes/testingrun only-stable-fixes` — the `Cleanup`/`Setenv`/… subtests get rewritten | `testingrunfix`, which is the default mode where those same closures **are** rewritten — the two modes are separated, not merely exercised |

## Fix applied end to end

Building the binary and running `qtlint -fix -require-testing-run -require-qt-c-receiver ./...` over the whole testdata corpus: `go build` exit 0 before, `-fix` exit 0, `go build` exit 0 after. A re-lint leaves only the five pre-existing report-only rule 9/10 cases (`if`-init and spread arguments) and no `require-testing-run` diagnostics, so the rule reaches a fixpoint.

## Gates

`go build ./...` 0 · `go vet ./...` 0 · `go test ./... -count=1` 0 · `go test -race ./... -count=1` 0 · `golangci-lint run ./...` 0 (0 issues) · `go mod tidy` + `git diff --exit-code go.mod go.sum` 0 · `make build` 0 · `make lint` 0 · `make test` 0 · coverage 82.5% against the 50% CI threshold.
