### PR TITLE
fix: open a line for a statement inserted into a one-line body

### DIFF
--- a/qtcbinding.go
+++ b/qtcbinding.go
@@ -298,8 +298,12 @@ func prependStmtEdit(pass *analysis.Pass, body *ast.BlockStmt, code string) anal
 	if at, ok := firstStmtLineStart(pass, body); ok {
 		return analysis.TextEdit{Pos: at, End: at, NewText: []byte(code + "\n")}
 	}
+	// Either the body is empty, or its first statement shares the brace's line.
+	// Opening a line before the inserted statement is not enough for the second
+	// case: without a closing newline the statement already on that line runs
+	// straight into the inserted one and the result does not parse.
 	at := body.Lbrace + 1
-	return analysis.TextEdit{Pos: at, End: at, NewText: []byte("\n" + code)}
+	return analysis.TextEdit{Pos: at, End: at, NewText: []byte("\n" + code + "\n")}
 }
 
 // firstStmtLineStart returns the start of the line holding body's first

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go
@@ -81,3 +81,7 @@ func assertNamedResult(t *testing.T) (c int) {
 	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c2.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
 	return 0
 }
+
+// A one-line function body: the brace, the statement and the closing brace
+// share a line, so the rewrite must open a line for the qt.New it inserts.
+func assertSingleLineBody(t *testing.T) { qt.Assert(t, 1, qt.Equals, 1) } // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go.golden
@@ -91,3 +91,10 @@ func assertNamedResult(t *testing.T) (c int) {
 	return 0
 }
 
+
+// A one-line function body: the brace, the statement and the closing brace
+// share a line, so the rewrite must open a line for the qt.New it inserts.
+func assertSingleLineBody(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(1, qt.Equals, 1)
+} // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -111,3 +111,11 @@ func TestTestScopedMethod(t *testing.T) {
 		c.Assert(1, qt.Equals, 1)
 	})
 }
+
+// A one-line closure body: the opening brace, the statement and the closing
+// brace share a line, so the rewrite must open a line for the statement it
+// inserts instead of running the two together.
+func TestSingleLineBody(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { c.Assert(1, qt.Equals, 1) }) // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+}

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -114,3 +114,12 @@ func TestTestScopedMethod(t *testing.T) {
 	})
 }
 
+// A one-line closure body: the opening brace, the statement and the closing
+// brace share a line, so the rewrite must open a line for the statement it
+// inserts instead of running the two together.
+func TestSingleLineBody(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	}) // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+}


### PR DESCRIPTION
Both opt-in rules emit a fix that does not parse when the target body has no line of its own.

## Reproduction

`prependStmtEdit` falls back to inserting after the opening brace when the first statement shares the brace's line. It opened a line **before** the inserted statement but not after it, so the statement already on that line ran straight into it:

```go
// input
c.Run(test.name, func(c *qt.C) { test.check(c) })

// emitted fix
t.Run(test.name, func(t *testing.T) {
c := qt.New(t) test.check(c) })
```

`go vet` on the result exits 1 with `expected ';', found test`. In the linter's own suite it surfaces as `error formatting resulting source: expected ';', found c`.

## How it was found

Applying `-require-testing-run` across a repository with **1234** reported sites. Exactly one had a one-line closure body, and it broke the file — 23 cascading parse errors, all from that single insertion. `go build ./...` did not catch it, because it does not build test files.

## Scope

The helper is shared, so `-require-qt-c-receiver` has the same defect on a one-line function body. Both fix fixtures gain the shape.

## Mutant

Reverting the change to `[]byte("\n" + code)` compiles (`go build` 0) and reddens **three** fixture packages — `qtcreceiverfix`, `qtcreceiverfix_only-stable-fixes` and `testingrunfix` — so the new fixtures cover the class for both rules, not just for the one that exposed it. Restored: suite green.

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 · `go test -race ./... -count=1` 0 · `golangci-lint run ./...` 0 issues.