### PR TITLE
fix: ask what can be called on a subtest's *qt.C, not what is written (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ The new parameter is named `t` unless the closure already refers to something ca
 
 **`-only-stable-fixes`** additionally withholds the fix — the diagnostic still fires — when the closure calls `Cleanup`, `Parallel`, `Setenv`, `Unsetenv`, `TempDir`, `Patch` or `Mkdir` on its own `*qt.C`. That is a review gate, not a correctness one: `C.Run` builds the closure's `*qt.C` from the subtest's own `*testing.T`, so both forms reach the same test, and measured against `quicktest v1.14.6` all seven behave identically either way — `Setenv`, `Unsetenv` and `Patch` restore at the same point, `Cleanup` runs at the same point, `TempDir` and `Mkdir` name the same subtest-scoped directory. What they have in common is that they tie a subtest to a test's *lifecycle* rather than to an assertion, which is where a reader has to agree that the subtest is the scope that was meant, so the flag lets a project migrate them by hand.
 
+Both sets are matched by asking **what can be called on the closure's `*qt.C`**, not what is written next to it. The `*qt.C` is followed through plain assignments — `cc := c` and on — and any use the rule cannot follow, such as `helper(c)` or `holder{c: c}`, is treated as reaching everything. That is what stops `cc := c; cc.Defer(...)` from shipping the panic through a route the method names never see; the cost is that a closure handing its `*qt.C` to a helper loses its automatic fix even when the helper does nothing interesting with it.
+
 When a fix is withheld for either reason, so are the fixes for any subtests nested inside it, and the receiver's declaration is kept, because the `c.Run` that was left alone still uses it.
 
 The rule does not fire when:

--- a/qtcbinding.go
+++ b/qtcbinding.go
@@ -56,6 +56,29 @@ func outermostFuncs(file *ast.File) []ast.Node {
 	return roots
 }
 
+// inspectWithParent walks the tree rooted at root in depth-first order,
+// calling fn for every node together with the node that contains it. The
+// root's parent is nil.
+//
+// A plain ast.Inspect answers "is this node an identifier"; a rule that has
+// to answer "and what is being done to it" needs the node above.
+func inspectWithParent(root ast.Node, fn func(n, parent ast.Node)) {
+	var stack []ast.Node
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		var parent ast.Node
+		if len(stack) > 0 {
+			parent = stack[len(stack)-1]
+		}
+		fn(n, parent)
+		stack = append(stack, n)
+		return true
+	})
+}
+
 // isTestingTPtr reports whether typ is exactly *testing.T.
 //
 // The opt-in rules that rewrite between a *testing.T and a *qt.C insist on

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -251,8 +251,8 @@ func bindingSite(lexParent *runSite, obj types.Object) *runSite {
 // rewrite has not introduced.
 func (p *runPlan) resolve(pass *analysis.Pass, onlyStableFixes bool) {
 	for _, s := range p.sites {
-		withheld := closureCallsCMethod(pass, s.run, deferredCMethods) ||
-			(onlyStableFixes && closureCallsCMethod(pass, s.run, testScopedCMethods))
+		reach := closureCReach(pass, s.run)
+		withheld := reach.deferred || (onlyStableFixes && reach.testScoped)
 		if s.outer != nil {
 			s.recvText = s.outer.tName
 			s.reported = s.outer.reported
@@ -429,30 +429,114 @@ func targetFromQtNew(pass *analysis.Pass, origins map[types.Object]qtCOrigin, ru
 	return tIdent.Name, true
 }
 
-// closureCallsCMethod reports whether run's closure names one of methods on
-// its own *qt.C parameter.
+// cReach says what a closure can do to its own *qt.C.
+type cReach struct {
+	// deferred is set when the closure can reach quicktest's
+	// deferred-execution API, and testScoped when it can reach a method whose
+	// scope is the test rather than the assertion.
+	deferred   bool
+	testScoped bool
+}
+
+// closureCReach works out what run's closure can do to its own *qt.C.
 //
-// A selector is enough: c.Cleanup taken as a method value and called later is
-// the same reach as calling it outright.
-func closureCallsCMethod(pass *analysis.Pass, run qtCRun, methods map[string]bool) bool {
+// The question the withholding rules ask is not "does this closure write
+// c.Defer" but "can Defer be called on this *qt.C", and the two come apart at
+// every indirection: cc := c, helper(c), holder{c: c}. Matching method names
+// against the closure's own parameter sees only the shapes that spell them
+// out, so this works the other way round. It follows the *qt.C through the
+// plain assignments it can see, classifies each use by the method that use
+// selects, and treats a use it cannot see through as reaching anything.
+//
+// A selector is enough on its own: c.Cleanup taken as a method value and
+// called later reaches exactly as far as calling it outright.
+func closureCReach(pass *analysis.Pass, run qtCRun) cReach {
 	if run.cObj == nil {
-		return false
+		return cReach{}
 	}
-	var found bool
-	ast.Inspect(run.lit, func(n ast.Node) bool {
-		if found {
-			return false
+	held := heldQtCObjects(pass, run.lit, run.cObj)
+
+	var reach cReach
+	inspectWithParent(run.lit, func(n, parent ast.Node) {
+		ident, ok := n.(*ast.Ident)
+		if !ok || !held[pass.TypesInfo.Uses[ident]] {
+			return
 		}
-		sel, ok := n.(*ast.SelectorExpr)
-		if !ok || !methods[sel.Sel.Name] {
-			return true
+		if sel, ok := parent.(*ast.SelectorExpr); ok && sel.X == ident {
+			switch {
+			case deferredCMethods[sel.Sel.Name]:
+				reach.deferred = true
+			case testScopedCMethods[sel.Sel.Name]:
+				reach.testScoped = true
+			}
+			return
 		}
-		if ident, ok := sel.X.(*ast.Ident); ok && pass.TypesInfo.Uses[ident] == run.cObj {
-			found = true
+		if _, rhs, ok := soleAssign(parent); ok && rhs == ident {
+			// The assignment that hands the *qt.C on is already followed.
+			return
 		}
-		return true
+		// The *qt.C goes somewhere this rule cannot follow: into a helper, a
+		// struct, a slice. Anything at all could be called on it there, and
+		// withholding a fix that was not needed costs only a fix.
+		reach.deferred = true
+		reach.testScoped = true
 	})
-	return found
+	return reach
+}
+
+// heldQtCObjects returns cObj together with every variable inside lit that a
+// plain one-to-one assignment hands it to. The set is closed under
+// repetition, so cc := c followed by ccc := cc reaches ccc.
+//
+// A destination joins the set whatever its type. The alternative is to read
+// the assignment as an escape, which would be the stricter answer for the one
+// shape this exists to follow.
+func heldQtCObjects(pass *analysis.Pass, lit *ast.FuncLit, cObj types.Object) map[types.Object]bool {
+	held := map[types.Object]bool{cObj: true}
+	for changed := true; changed; {
+		changed = false
+		ast.Inspect(lit, func(n ast.Node) bool {
+			lhs, rhs, ok := soleAssign(n)
+			if !ok {
+				return true
+			}
+			src, ok := rhs.(*ast.Ident)
+			if !ok || !held[pass.TypesInfo.Uses[src]] {
+				return true
+			}
+			dst, ok := lhs.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			obj := pass.TypesInfo.Defs[dst]
+			if obj == nil {
+				obj = pass.TypesInfo.Uses[dst]
+			}
+			if obj == nil || held[obj] {
+				return true
+			}
+			held[obj] = true
+			changed = true
+			return true
+		})
+	}
+	return held
+}
+
+// soleAssign returns the two sides of a node that assigns one value to one
+// destination, which is the only shape a *qt.C is followed through.
+func soleAssign(n ast.Node) (lhs, rhs ast.Expr, ok bool) {
+	switch node := n.(type) {
+	case *ast.AssignStmt:
+		if len(node.Lhs) == 1 && len(node.Rhs) == 1 {
+			return node.Lhs[0], node.Rhs[0], true
+		}
+	case *ast.ValueSpec:
+		if len(node.Names) == 1 && len(node.Values) == 1 {
+			return node.Names[0], node.Values[0], true
+		}
+	}
+	return nil, nil, false
 }
 
 // newRunParam renders the closure's rewritten parameter, keeping the shape

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -133,6 +133,24 @@ func TestDoneWithheldByDefault(t *testing.T) {
 	})
 }
 
+// deferSomething reaches Defer through a parameter.
+func deferSomething(c *qt.C) { c.Defer(func() {}) }
+
+// Defer reached indirectly is withheld by default as well, which is the whole
+// point of asking what can be called on the *qt.C rather than what is written
+// next to it. The alias is followed; the helper call is not, and a use that
+// cannot be followed is treated as reaching anything.
+func TestIndirectDeferWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("alias", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		cc := c
+		cc.Defer(func() {})
+	})
+	c.Run("helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		deferSomething(c)
+	})
+}
+
 // A one-line closure body: the opening brace, the statement and the closing
 // brace share a line, so the rewrite must open a line for the statement it
 // inserts instead of running the two together.

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -135,6 +135,24 @@ func TestDoneWithheldByDefault(t *testing.T) {
 	})
 }
 
+// deferSomething reaches Defer through a parameter.
+func deferSomething(c *qt.C) { c.Defer(func() {}) }
+
+// Defer reached indirectly is withheld by default as well, which is the whole
+// point of asking what can be called on the *qt.C rather than what is written
+// next to it. The alias is followed; the helper call is not, and a use that
+// cannot be followed is treated as reaching anything.
+func TestIndirectDeferWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("alias", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		cc := c
+		cc.Defer(func() {})
+	})
+	c.Run("helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		deferSomething(c)
+	})
+}
+
 // A one-line closure body: the opening brace, the statement and the closing
 // brace share a line, so the rewrite must open a line for the statement it
 // inserts instead of running the two together.

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -47,6 +47,36 @@ func TestWithheldMethods(t *testing.T) {
 	})
 }
 
+// holder puts a *qt.C somewhere the rule cannot follow it.
+type holder struct{ c *qt.C }
+
+// cleanUp reaches a test-scoped method through a parameter.
+func cleanUp(c *qt.C) { c.Cleanup(func() {}) }
+
+// The indirect routes to a test-scoped method are withheld too. Naming the
+// methods and matching them against the closure's own parameter sees only the
+// closures that spell them out; an alias, a helper and a struct field all
+// reach the same methods without ever writing them next to c.
+func TestIndirectReach(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("alias", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		cc := c
+		cc.Cleanup(func() {})
+	})
+	c.Run("helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		cleanUp(c)
+	})
+	c.Run("field", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		h := holder{c: c}
+		h.c.Setenv("K", "V")
+	})
+	c.Run("method value", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		f := c.Cleanup
+		f(func() {})
+	})
+}
+
 // An unstable outer withholds its fix, and the nested subtest withholds with
 // it: rewriting the inner alone would name a t the outer has not introduced.
 func TestNestedUnstableOuter(t *testing.T) {

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -48,6 +48,36 @@ func TestWithheldMethods(t *testing.T) {
 	})
 }
 
+// holder puts a *qt.C somewhere the rule cannot follow it.
+type holder struct{ c *qt.C }
+
+// cleanUp reaches a test-scoped method through a parameter.
+func cleanUp(c *qt.C) { c.Cleanup(func() {}) }
+
+// The indirect routes to a test-scoped method are withheld too. Naming the
+// methods and matching them against the closure's own parameter sees only the
+// closures that spell them out; an alias, a helper and a struct field all
+// reach the same methods without ever writing them next to c.
+func TestIndirectReach(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("alias", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		cc := c
+		cc.Cleanup(func() {})
+	})
+	c.Run("helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		cleanUp(c)
+	})
+	c.Run("field", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		h := holder{c: c}
+		h.c.Setenv("K", "V")
+	})
+	c.Run("method value", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		f := c.Cleanup
+		f(func() {})
+	})
+}
+
 // An unstable outer withholds its fix, and the nested subtest withholds with
 // it: rewriting the inner alone would name a t the outer has not introduced.
 func TestNestedUnstableOuter(t *testing.T) {


### PR DESCRIPTION
Fixes #50. Stacked on #52.

`closureUsesTestScopedMethod` matched the withheld method names against selectors whose receiver identifier resolved to the closure's own `*qt.C`, so every indirect route past it was rewritten. Reproduced with `-fix -require-testing-run -only-stable-fixes`, all four rewritten:

- `cc := c; cc.Cleanup(func(){})`
- `helper(c)` where `helper` calls `c.Cleanup`
- `h := holder{c: c}; h.c.Setenv(...)`
- `cc := c; cc.Defer(func(){})`

The last one ships the panic through the flag whose job is to prevent it: the rewritten file panicked with `Done not called after Defer` against real `quicktest v1.14.6`.

## What changed

The classification is inverted. `closureCReach` follows the `*qt.C` through the plain one-to-one assignments it can see, classifies each use by the method that use selects, and treats a use it cannot see through — a call argument, a composite literal element, anything that is not a selector on the value — as reaching everything.

An escape therefore withholds unconditionally, not just under `-only-stable-fixes`, because what it could reach includes `Defer`.

The cost, stated plainly: a closure handing its `*qt.C` to a helper loses its automatic fix even when the helper does nothing interesting with it. That is the direction whose failure mode is a diagnostic the author still acts on, rather than a rewrite that panics. The alternative — resolving intra-package calls to see what the helper does — is a real inter-procedural analysis and is not what this fix is.

The method-value route, `f := c.Cleanup`, was already caught by selecting on the name and still is; it has a fixture now.

## Mutant evidence

Both mutants compile (`go build ./...` and `go vet ./...` exit 0).

- **50A** — a use that selects no method calls no method, so passing the `*qt.C` somewhere reaches nothing by itself. `go test ./... -count=1` exits **1**: `TestFixes/testingrunfix` on the helper route under default flags, `TestFixes/testingrun_only-stable-fixes` on the helper and struct-field routes. Reverted: exits **0**.
- **50B** — only the closure's own parameter holds the `*qt.C`; a copy of it is a different variable. `go test ./... -count=1` exits **1**: both suites on the alias route, `-t.Run("alias", …)` against `+c.Run("alias", …)`. Reverted: exits **0**.

The two mutants split the fixtures cleanly: 50A leaves the alias route green and 50B leaves the helper and field routes green, so neither fixture group is carrying the other.

## End to end

A fresh package with all five routes, `-fix -require-testing-run -only-stable-fixes`: the tool exits 0 and rewrites **nothing** (`diff` against the original exits 0), and the file still passes.

## Gates

`go build ./...` 0, `go vet ./...` 0, `go test ./... -count=1` 0, `go test -race ./... -count=1` 0, `golangci-lint run ./...` 0, `go mod tidy` then `git diff --exit-code go.mod go.sum` 0.
