### PR TITLE
fix: withhold the fix for quicktest deferred-execution API (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ func TestExample(t *testing.T) {
 
 Note that this repository's own tests are written in the target form. Enabling this rule while leaving a `c.Run` example in the project's own style guide is how the rule gets argued with six months later, so a project adopting it should update its contributor documentation at the same time — most `quicktest` examples in the wild show `c.Run`.
 
-**Auto-fix:** ✅ for every reported site, and the rewrite touches four things at once so that the result compiles:
+**Auto-fix:** ✅ for every reported site except the ones noted below, and the rewrite touches four things at once so that the result compiles:
 
 - the receiver of `.Run` becomes the `*testing.T` the `*qt.C` was made from;
 - the closure parameter becomes `t *testing.T`, keeping the original `*qt.C` identifier for the body to use;
@@ -504,7 +504,11 @@ The new parameter is named `t` unless the closure already refers to something ca
 
 **A whole function is planned before any of it is reported**, because its sites decide each other's fate. Whether the receiver's declaration survives depends on which of its `c.Run` calls are actually rewritten, so a call the rule declined — one whose `t` is shadowed where the rewrite would write it, say — keeps that declaration alive for every sibling. And a nested call is declined whenever the call around it is, since rewriting it alone would attach the subtest to the parent test instead. Answering "which sites get edits" and "does the declaration survive" separately is how a declaration comes to be deleted while a declined sibling still names it.
 
-**`-only-stable-fixes`** withholds the fix — the diagnostic still fires — when the closure calls `Cleanup`, `Parallel`, `Setenv`, `TempDir`, `Patch`, `Defer` or `Mkdir` on its own `*qt.C`. Those bind to whichever test the `*qt.C` came from, and the rewrite deliberately rebinds them to the subtest; a project relying on `c.Run`'s parent-scoped behavior would see a change. That is the one shape where this rewrite can alter what a test does, which is exactly what the flag is for. When a fix is withheld, so are the fixes for any subtests nested inside it, and the receiver's declaration is kept, because the withheld `c.Run` still uses it.
+**`Defer` and `Done` are withheld whatever the flags say.** They are quicktest's deferred-execution API, and they are the one shape where this rewrite can turn a passing test into a panicking one. `(*C).Defer` registers a cleanup that panics unless `Done` has run first; `C.Run` wraps the closure it calls in `defer c2.Done()`, a bare `c := qt.New(t)` does not, and nothing in the rewritten closure would. Measured against `quicktest v1.14.6`: a subtest calling `c.Defer` passes under `c.Run` and panics with `Done not called after Defer` under `t.Run` plus `qt.New`. The diagnostic still fires; the fix does not.
+
+**`-only-stable-fixes`** additionally withholds the fix — the diagnostic still fires — when the closure calls `Cleanup`, `Parallel`, `Setenv`, `Unsetenv`, `TempDir`, `Patch` or `Mkdir` on its own `*qt.C`. That is a review gate, not a correctness one: `C.Run` builds the closure's `*qt.C` from the subtest's own `*testing.T`, so both forms reach the same test, and measured against `quicktest v1.14.6` all seven behave identically either way — `Setenv`, `Unsetenv` and `Patch` restore at the same point, `Cleanup` runs at the same point, `TempDir` and `Mkdir` name the same subtest-scoped directory. What they have in common is that they tie a subtest to a test's *lifecycle* rather than to an assertion, which is where a reader has to agree that the subtest is the scope that was meant, so the flag lets a project migrate them by hand.
+
+When a fix is withheld for either reason, so are the fixes for any subtests nested inside it, and the receiver's declaration is kept, because the `c.Run` that was left alone still uses it.
 
 The rule does not fire when:
 

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -8,22 +8,47 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
+// deferredCMethods are quicktest's deferred-execution API, and they are the
+// one shape where this rewrite can turn a passing test into a panicking one.
+//
+// (*C).Defer registers a cleanup that panics unless Done has run first.
+// C.Run wraps the closure it calls in "defer c2.Done()"; a bare
+// c := qt.New(t) does not, and nothing in the rewritten closure would. So a
+// closure that calls Defer keeps its diagnostic and loses its fix whatever
+// -only-stable-fixes says. Done travels with Defer because the two are one
+// API, and withholding a fix nobody needed costs only a fix.
+//
+// Measured against quicktest v1.14.6: the c.Run form of a subtest calling
+// c.Defer passes, and the t.Run plus qt.New form panics with "Done not
+// called after Defer".
+var deferredCMethods = map[string]bool{
+	"Defer": true,
+	"Done":  true,
+}
+
 // testScopedCMethods are the *qt.C methods that act on the test the *qt.C was
 // made from rather than on the assertion at hand.
 //
-// Under c.Run they bind to whichever test the receiver came from; after the
-// rewrite the closure's *qt.C is made from the subtest, which is what a
-// reader almost always meant. "Almost always" is the whole reason
-// -only-stable-fixes exists, so a closure that calls one of these keeps its
-// diagnostic but loses its automatic fix under that flag.
+// The rewrite does not move them. C.Run builds the closure's *qt.C from the
+// subtest's own *testing.T, so both forms reach the same test: measured
+// against quicktest v1.14.6, Setenv, Unsetenv and Patch restore at the same
+// point, Cleanup runs at the same point, and TempDir and Mkdir name the same
+// subtest-scoped directory either way.
+//
+// They are still the calls that tie a subtest to a test's lifecycle rather
+// than to an assertion, which is where a reader has to agree that the subtest
+// is the scope that was meant. -only-stable-fixes withholds the fix for a
+// closure that calls one so a project can migrate those by hand; the
+// diagnostic still fires. That is a review gate, not a correctness one. The
+// correctness one is deferredCMethods, and it is not optional.
 var testScopedCMethods = map[string]bool{
 	"Cleanup":  true,
-	"Defer":    true,
 	"Mkdir":    true,
 	"Parallel": true,
 	"Patch":    true,
 	"Setenv":   true,
 	"TempDir":  true,
+	"Unsetenv": true,
 }
 
 // qtCRun describes a c.Run(name, func(c *qt.C) { … }) call.
@@ -226,7 +251,8 @@ func bindingSite(lexParent *runSite, obj types.Object) *runSite {
 // rewrite has not introduced.
 func (p *runPlan) resolve(pass *analysis.Pass, onlyStableFixes bool) {
 	for _, s := range p.sites {
-		withheld := onlyStableFixes && closureUsesTestScopedMethod(pass, s.run)
+		withheld := closureCallsCMethod(pass, s.run, deferredCMethods) ||
+			(onlyStableFixes && closureCallsCMethod(pass, s.run, testScopedCMethods))
 		if s.outer != nil {
 			s.recvText = s.outer.tName
 			s.reported = s.outer.reported
@@ -403,10 +429,12 @@ func targetFromQtNew(pass *analysis.Pass, origins map[types.Object]qtCOrigin, ru
 	return tIdent.Name, true
 }
 
-// closureUsesTestScopedMethod reports whether run's closure calls one of the
-// *qt.C methods that bind to a test rather than to an assertion, on its own
-// parameter.
-func closureUsesTestScopedMethod(pass *analysis.Pass, run qtCRun) bool {
+// closureCallsCMethod reports whether run's closure names one of methods on
+// its own *qt.C parameter.
+//
+// A selector is enough: c.Cleanup taken as a method value and called later is
+// the same reach as calling it outright.
+func closureCallsCMethod(pass *analysis.Pass, run qtCRun, methods map[string]bool) bool {
 	if run.cObj == nil {
 		return false
 	}
@@ -416,7 +444,7 @@ func closureUsesTestScopedMethod(pass *analysis.Pass, run qtCRun) bool {
 			return false
 		}
 		sel, ok := n.(*ast.SelectorExpr)
-		if !ok || !testScopedCMethods[sel.Sel.Name] {
+		if !ok || !methods[sel.Sel.Name] {
 			return true
 		}
 		if ident, ok := sel.X.(*ast.Ident); ok && pass.TypesInfo.Uses[ident] == run.cObj {

--- a/testdata/src/github.com/frankban/quicktest/quicktest.go
+++ b/testdata/src/github.com/frankban/quicktest/quicktest.go
@@ -1,5 +1,11 @@
 // Package quicktest is a stub for testing purposes.
 // This is not the real quicktest package.
+//
+// The rules that reason about *qt.C methods decide what to do from the method
+// name, so a name this stub gets wrong or leaves out is a case the fixtures
+// cannot reach. Signatures are copied from quicktest v1.14.6; the real C
+// embeds testing.TB and inherits Cleanup, TempDir and the rest from it, which
+// this stub spells out instead.
 package quicktest
 
 import "testing"
@@ -35,9 +41,12 @@ func (c *C) Cleanup(f func()) {}
 // Defer registers f to be called when the test's Done method is called.
 func (c *C) Defer(f func()) {}
 
-// Mkdir creates a directory that is removed when the test is done.
-func (c *C) Mkdir(name string) string {
-	return name
+// Done calls the functions registered by Defer, in reverse order.
+func (c *C) Done() {}
+
+// Mkdir makes a temporary directory and returns its name.
+func (c *C) Mkdir() string {
+	return ""
 }
 
 // Parallel signals that the test is to be run in parallel.
@@ -48,6 +57,9 @@ func (c *C) Patch(dest, value any) {}
 
 // Setenv sets an environment variable for the duration of the test.
 func (c *C) Setenv(key, value string) {}
+
+// Unsetenv unsets an environment variable for the duration of the test.
+func (c *C) Unsetenv(name string) {}
 
 // TempDir returns a temporary directory removed when the test is done.
 func (c *C) TempDir() string {

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -112,6 +112,27 @@ func TestTestScopedMethod(t *testing.T) {
 	})
 }
 
+// A closure calling Defer is withheld with no flag set. C.Run calls Done on
+// the *qt.C it hands the closure and a bare qt.New(t) does not, so this
+// rewrite would replace a passing test with one that panics with "Done not
+// called after Defer". The receiver's declaration stays, because the c.Run
+// that was left alone still uses it.
+func TestDeferWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Defer(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Done is the other half of the same API and is withheld the same way.
+func TestDoneWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Done()
+	})
+}
+
 // A one-line closure body: the opening brace, the statement and the closing
 // brace share a line, so the rewrite must open a line for the statement it
 // inserts instead of running the two together.

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -114,6 +114,27 @@ func TestTestScopedMethod(t *testing.T) {
 	})
 }
 
+// A closure calling Defer is withheld with no flag set. C.Run calls Done on
+// the *qt.C it hands the closure and a bare qt.New(t) does not, so this
+// rewrite would replace a passing test with one that panics with "Done not
+// called after Defer". The receiver's declaration stays, because the c.Run
+// that was left alone still uses it.
+func TestDeferWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Defer(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Done is the other half of the same API and is withheld the same way.
+func TestDoneWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Done()
+	})
+}
+
 // A one-line closure body: the opening brace, the statement and the closing
 // brace share a line, so the rewrite must open a line for the statement it
 // inserts instead of running the two together.

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -39,11 +39,11 @@ func TestWithheldMethods(t *testing.T) {
 	c.Run("patch", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c.Patch(nil, nil)
 	})
-	c.Run("defer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
-		c.Defer(func() {})
+	c.Run("unsetenv", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Unsetenv("K")
 	})
 	c.Run("mkdir", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
-		c.Assert(c.Mkdir("d"), qt.Equals, "d")
+		c.Assert(c.Mkdir(), qt.Not(qt.Equals), "")
 	})
 }
 

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -40,11 +40,11 @@ func TestWithheldMethods(t *testing.T) {
 	c.Run("patch", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c.Patch(nil, nil)
 	})
-	c.Run("defer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
-		c.Defer(func() {})
+	c.Run("unsetenv", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Unsetenv("K")
 	})
 	c.Run("mkdir", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
-		c.Assert(c.Mkdir("d"), qt.Equals, "d")
+		c.Assert(c.Mkdir(), qt.Not(qt.Equals), "")
 	})
 }
 


### PR DESCRIPTION
Fixes #49. Stacked on #51.

## The measurement

Read `quicktest v1.14.6` from the module cache and ran both forms of each method against it.

`C.Run` builds `c2 := New(args[0])` from the **subtest's** `testing.TB` and wraps the closure in `defer c2.Done()`. So six of the seven withheld methods are behavior-preserving under the rewrite, and the rationale in the comment and the README said the opposite of what the library does. Executed, both forms, all passing:

| method | checked |
| --- | --- |
| `Setenv` | restored to the outer value after the subtest, both forms |
| `Unsetenv` | unset inside, restored after, both forms |
| `Cleanup` | had run by the time the subtest returned, both forms |
| `TempDir` / `Mkdir` | path contains the subtest name, both forms |
| `Patch` | restored after the subtest, both forms |

`Parallel` is stated from reading, not measured: both forms call `Parallel()` on the same subtest `*testing.T`.

**`Defer` is the real one, and it was rewritten by default:**

```
--- PASS: TestDeferCRun
--- FAIL: TestDeferTRun
panic: Done not called after Defer
	quicktest.(*C).Defer.func1() quicktest@v1.14.6/quicktest.go:118
```

## The direction chosen: always withhold

`Defer` and `Done` move into a set withheld whatever the flags say, rather than having the rewrite emit `defer c.Done()`.

- Withholding fails toward a diagnostic the author still has to act on. Emitting `Done` has to detect **every** route to `Defer` correctly, and a miss there ships the panic — see the sibling issue #50 for how many routes there are.
- `Defer` is deprecated in quicktest ("in Go >= 1.14 use testing.TB.Cleanup instead"). Writing new calls to a deprecated API into a project's tests is not a repair worth automating.

The remaining set keeps its flag with the rationale corrected: those methods tie a subtest to a test's *lifecycle* rather than to an assertion, which is worth a reviewer's eye. It is a review gate, not a correctness one, and the README now says so.

## Also

`Unsetenv` joins the set — real quicktest has `(*C).Unsetenv` in `patch.go`, calling `c.Setenv`, which was listed while `Unsetenv` was not.

The testdata stub gains `Unsetenv` and `Done`, and its `Mkdir` loses the parameter the real `Mkdir()` never had.

## Mutant evidence

All mutants compile (`go build ./...` and `go vet ./...` exit 0).

- **49A** — the deferred set is just another entry in the set the flag gates, so a default run rewrites it. `go test ./... -count=1` exits **1**: `TestFixes/testingrunfix`, both new `Defer`/`Done` fixtures rewritten. Reverted: exits **0**.
- **49B** — `Unsetenv` omitted from the set. `go test ./... -count=1` exits **1**: `TestFixes/testingrun_only-stable-fixes`, the `unsetenv` subtest rewritten under the flag. Reverted: exits **0**. This is a data correction to a curated list, so the only wrong implementation available is the omission itself; stated plainly rather than dressed up as an algorithm change.
- **49C** — the stub's `Mkdir` takes a name again. `go test ./... -count=1` exits **1** in `TestFixes/testingrun_only-stable-fixes` **and** `TestGoldenFilesCompile`, both `not enough arguments in call to c.Mkdir`. That is a compile error, and here it is the intended reason: the fixture calls `c.Mkdir()`, which only type-checks against the corrected signature. Reverted: exits **0**.

## Gates

`go build ./...` 0, `go vet ./...` 0, `go test ./... -count=1` 0, `go test -race ./... -count=1` 0, `golangci-lint run ./...` 0, `go mod tidy` then `git diff --exit-code go.mod go.sum` 0.

---

Replaces #52, which GitHub closed automatically when its base branch was deleted by the merge of #51. Same commit, rebased onto master; no content change.