### PR TITLE
fix: emit diagnostics in source order (#57)

### DIFF
--- a/qtlint.go
+++ b/qtlint.go
@@ -36,11 +36,13 @@ package qtlint
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"go/ast"
 	"go/format"
 	"go/token"
 	"go/types"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -111,24 +113,66 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		return nil, nil
 	}
 
-	// Filter for nodes we want to inspect.
-	nodeFilter := []ast.Node{
-		(*ast.CallExpr)(nil),
-		(*ast.IfStmt)(nil),
-	}
-
-	insp.Preorder(nodeFilter, func(n ast.Node) {
-		switch n := n.(type) {
-		case *ast.CallExpr:
-			checkQuicktestCall(pass, n)
-		case *ast.IfStmt:
-			a.checkErrNilFatalPattern(pass, n)
+	inSourceOrder(pass, func() {
+		// Filter for nodes we want to inspect.
+		nodeFilter := []ast.Node{
+			(*ast.CallExpr)(nil),
+			(*ast.IfStmt)(nil),
 		}
+
+		insp.Preorder(nodeFilter, func(n ast.Node) {
+			switch n := n.(type) {
+			case *ast.CallExpr:
+				checkQuicktestCall(pass, n)
+			case *ast.IfStmt:
+				a.checkErrNilFatalPattern(pass, n)
+			}
+		})
+
+		a.runOptInRules(pass, insp)
 	})
 
-	a.runOptInRules(pass, insp)
-
 	return nil, nil
+}
+
+// inSourceOrder runs rules with pass.Report buffered and then emits everything
+// they reported ordered by position.
+//
+// The rules do not share one walk. The default set rides a single Preorder,
+// -require-qt-c-receiver needs the enclosing stack and so takes a WithStack of
+// its own, and -require-testing-run plans a whole function at a time and walks
+// the files itself. Reporting as each walk reaches a site therefore orders the
+// output by traversal rather than by position: a diagnostic from a later walk
+// comes after one from an earlier walk however far up the file it sits.
+//
+// No driver puts that right: singlechecker prints diagnostics in the order the
+// analyzer reported them, and so does the -json encoding of them, so what the
+// rules emit is what a reader compares against the file. Sorting here keeps
+// that promise for every pair of rules rather than for the pairs that happen
+// to share a walk today.
+//
+// One cost is worth naming: the driver validates a diagnostic's SuggestedFixes
+// inside pass.Report, so buffering moves that validation from the moment a
+// rule reports to the end of the pass, and a malformed fix panics with the
+// reporting rule no longer on the stack.
+func inSourceOrder(pass *analysis.Pass, rules func()) {
+	direct := pass.Report
+	var collected []analysis.Diagnostic
+
+	pass.Report = func(d analysis.Diagnostic) { collected = append(collected, d) }
+	defer func() {
+		pass.Report = direct
+		// Stable, so that two rules reporting the same position keep the order
+		// the rules ran in rather than swapping between builds.
+		slices.SortStableFunc(collected, func(x, y analysis.Diagnostic) int {
+			return cmp.Compare(x.Pos, y.Pos)
+		})
+		for _, d := range collected {
+			direct(d)
+		}
+	}()
+
+	rules()
 }
 
 // runOptInRules runs the house-style rules that are off unless their flag is

--- a/qtlint_test.go
+++ b/qtlint_test.go
@@ -1,6 +1,10 @@
 package qtlint_test
 
 import (
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 
 	"golang.org/x/tools/go/analysis"
@@ -95,6 +99,47 @@ func TestAnalyzer(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		analysistest.Run(t, testdata, analyzer, "testingrunoff")
 	})
+
+	// Both opt-in rules at once, which no other test turns on together, plus a
+	// default-set diagnostic between them. The want comments cover the
+	// combined path; the order assertion covers what the want comments cannot,
+	// since analysistest matches each want by position and never looks at the
+	// sequence the diagnostics arrived in.
+	t.Run("both opt-in rules", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-qt-c-receiver")
+		setFlag(t, analyzer, "require-testing-run")
+		results := analysistest.Run(t, testdata, analyzer, "bothrules")
+		assertReportedOrder(t, results, []string{
+			"bothrules.go:29:2: qtlint: use c.Assert(...) instead of qt.Assert(t, ...)",
+			"bothrules.go:31:2: qtlint: use t.Run with a per-subtest qt.New instead of c.Run",
+			"bothrules.go:32:12: qtlint: use qt.HasLen instead of len(x), qt.Equals",
+			"bothrules.go:35:2: qtlint: use c.Check(...) instead of qt.Check(t, ...)",
+		})
+	})
+}
+
+// assertReportedOrder checks the sequence of diagnostics a pass reported,
+// which is the sequence a driver prints: neither singlechecker nor the -json
+// encoder sorts, so the analyzer's report order is the user's read order.
+//
+// The positions are rendered relative to the file's base name so that the
+// expectation reads like the output a user sees.
+func assertReportedOrder(t *testing.T, results []*analysistest.Result, want []string) {
+	t.Helper()
+
+	var got []string
+	for _, res := range results {
+		for _, diag := range res.Diagnostics {
+			posn := res.Pass.Fset.Position(diag.Pos)
+			got = append(got, fmt.Sprintf("%s:%d:%d: %s",
+				filepath.Base(posn.Filename), posn.Line, posn.Column, diag.Message))
+		}
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("diagnostics reported out of order:\ngot:\n\t%s\nwant:\n\t%s",
+			strings.Join(got, "\n\t"), strings.Join(want, "\n\t"))
+	}
 }
 
 // setFlag enables a boolean analyzer flag, failing the test if the flag does

--- a/testdata/src/bothrules/bothrules.go
+++ b/testdata/src/bothrules/bothrules.go
@@ -1,0 +1,36 @@
+// Package bothrules is the fixture for the two opt-in rules running together.
+//
+// Every other fixture turns on at most one of them, so the combined path — two
+// house-style rules and the default set reporting into one pass — had no
+// coverage at all. The order the diagnostics come out in is pinned by
+// TestAnalyzer, which reads the reported sequence rather than the want
+// comments: a want comment is matched by position and says nothing about the
+// order its diagnostic arrived in.
+package bothrules
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The three rules fire on interleaved lines, and no two of them share a walk:
+// the len/qt.Equals report comes from the default Preorder, the qt.Assert and
+// qt.Check reports from -require-qt-c-receiver's WithStack, and the c.Run
+// report from -require-testing-run's own walk of the file.
+//
+// c is asserted on directly as well, so -require-testing-run keeps its
+// declaration and the two rules' rewrites do not contradict each other.
+func TestBothRules(t *testing.T) {
+	nums := []int{1, 2, 3}
+	c := qt.New(t)
+	c.Assert(0, qt.Equals, 0)
+
+	qt.Assert(t, 1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(len(nums), qt.Equals, 3) // want "qtlint: use qt.HasLen instead of len\\(x\\), qt.Equals"
+	})
+
+	qt.Check(t, 3, qt.Equals, 3) // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+}


### PR DESCRIPTION
Closes #57.

## What was wrong

The rules do not share one walk. The default set rides a single `insp.Preorder`, `-require-qt-c-receiver` takes an `insp.WithStack` of its own because it needs the enclosing function, and `-require-testing-run` plans a whole function at a time and walks the files itself. Reporting as each walk reaches a site orders the output by traversal rather than by position, and no driver puts that right: `singlechecker` prints diagnostics in the order the analyzer reported them, and so does `-json`.

## The class is wider than the report

The report names the two opt-in rules against each other, which is what moving `-require-testing-run` off the shared traversal made visible. Measured with a `v1.8.1` binary on a file whose default-set diagnostic sits below both opt-in ones, the default diagnostic already came out first with *either* opt-in rule alone:

```
$ qtlint-v1.8.1 -require-qt-c-receiver -require-testing-run ./issue57/
order_test.go:14:12: qtlint: use qt.HasLen instead of len(x), qt.Equals
order_test.go:13:2:  qtlint: use t.Run with a per-subtest qt.New instead of c.Run
order_test.go:12:2:  qtlint: use c.Assert(...) instead of qt.Assert(t, ...)
order_test.go:16:2:  qtlint: use c.Check(...) instead of qt.Check(t, ...)

$ qtlint-v1.8.1 -require-qt-c-receiver ./issue57/
order_test.go:14:12: ...HasLen...
order_test.go:12:2:  ...c.Assert...
order_test.go:16:2:  ...c.Check...
```

So the sort goes around every rule rather than around the pair the report names, and stays correct as rules are added. `inSourceOrder` buffers `pass.Report` for the duration of the pass and replays it sorted by position, stably, so two rules reporting the same position keep the order the rules ran in. It is pass-local, not analyzer-state, because `run` is called concurrently for different packages.

One cost is named in the comment: the driver validates `SuggestedFixes` inside `pass.Report`, so buffering moves that validation to the end of the pass.

After:

```
$ qtlint -require-qt-c-receiver -require-testing-run ./issue57/
order_test.go:12:2:  qtlint: use c.Assert(...) instead of qt.Assert(t, ...)
order_test.go:13:2:  qtlint: use t.Run with a per-subtest qt.New instead of c.Run
order_test.go:14:12: qtlint: use qt.HasLen instead of len(x), qt.Equals
order_test.go:16:2:  qtlint: use c.Check(...) instead of qt.Check(t, ...)
```

## Coverage

`testdata/src/bothrules` is the first fixture anywhere to enable both opt-in rules at once; that path had no coverage. Its `want` comments alone cannot pin the ordering, because `analysistest` matches each `want` by position and never looks at the sequence — so the test reads the reported sequence out of `analysistest.Result.Diagnostics` and compares it whole.

Stated plainly: the `want` comments in the new fixture pass both before and after this change. The order assertion is the load-bearing half.

## Mutant

The cheaper wrong implementation: buffer and sort only `runOptInRules`, which is what the report's title alone would suggest. It compiles, `go vet` is clean, and it is wrong because default-set diagnostics still all come out first.

```
$ go build ./... && go vet ./...   # 0, 0
$ go test ./... -count=1
--- FAIL: TestAnalyzer/both_opt-in_rules
    diagnostics reported out of order:
    got:
        bothrules.go:32:12: qtlint: use qt.HasLen instead of len(x), qt.Equals
        bothrules.go:29:2:  qtlint: use c.Assert(...) instead of qt.Assert(t, ...)
        bothrules.go:31:2:  qtlint: use t.Run with a per-subtest qt.New instead of c.Run
        bothrules.go:35:2:  qtlint: use c.Check(...) instead of qt.Check(t, ...)
    want: 29, 31, 32, 35
exit 1
```

The two opt-in rules are now in source order relative to each other and the default one is still first: the mutant fails for the intended reason and for no other. Reverted, `go test ./... -count=1` is exit 0.

The same test run against the unfixed `qtlint.go` fails with `got: 32, 31, 29, 35`, which is the `v1.8.1` behavior exactly.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./... -count=1`, `golangci-lint run ./...` all exit 0. `go mod tidy` then `git diff --exit-code go.mod go.sum` exits 0.