### PR TITLE
fix: keep a receiver visible across the closures it is written across (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,19 @@ The new parameter is named `t` unless the closure already refers to something ca
 
 **Nested subtests** are rewritten as one consistent set of edits. The inner call names the parameter the outer rewrite introduces, which is resolved before the inner one is planned; applying an outer rewrite on its own would otherwise leave an inner `c.Run` whose receiver no longer exists.
 
+**A receiver bound further out than the closure the call sits in** takes one more precaution. The rewrite writes that receiver's name *across* the closures in between, and those closures are being given parameters by the same plan, so a parameter introduced in between would hide the one that was meant:
+
+```go
+c.Run("outer", func(c *qt.C) {
+    c.Run("middle", func(mid *qt.C) { // renames its own C, so c below still means "outer"
+        mid.Assert(0, qt.Equals, 0)
+        c.Run("deep", func(c *qt.C) { /* ... */ })
+    })
+})
+```
+
+Naming every closure's parameter `t` here leaves `deep` reading the *middle* subtest's `t`. The result compiles and passes, and the only thing that changes is that the subtest moves from `outer/deep` to `outer/middle/deep`, which breaks every `-run` filter and anything else keyed on test names. So a closure that a name is written across is kept clear of that name, and only such a closure is: a plain nest wants the shadowing, since that is what lets each level of `t.Run(name, func(t *testing.T))` call itself `t`. The name written across may come from the plan — an enclosing closure's new parameter — or from the source, as the `t` behind a `c := qt.New(t)` declared outside the closure in between; both are kept clear of.
+
 **A whole function is planned before any of it is reported**, because its sites decide each other's fate. Whether the receiver's declaration survives depends on which of its `c.Run` calls are actually rewritten, so a call the rule declined — one whose `t` is shadowed where the rewrite would write it, say — keeps that declaration alive for every sibling. And a nested call is declined whenever the call around it is, since rewriting it alone would attach the subtest to the parent test instead. Answering "which sites get edits" and "does the declaration survive" separately is how a declaration comes to be deleted while a declined sibling still names it.
 
 **`Defer` and `Done` are withheld whatever the flags say.** They are quicktest's deferred-execution API, and they are the one shape where this rewrite can turn a passing test into a panicking one. `(*C).Defer` registers a cleanup that panics unless `Done` has run first; `C.Run` wraps the closure it calls in `defer c2.Done()`, a bare `c := qt.New(t)` does not, and nothing in the rewritten closure would. Measured against `quicktest v1.14.6`: a subtest calling `c.Defer` passes under `c.Run` and panics with `Done not called after Defer` under `t.Run` plus `qt.New`. The diagnostic still fires; the fix does not.

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -68,6 +68,15 @@ func TestFixes(t *testing.T) {
 		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "testingrunalias")
 	})
 
+	// A site whose receiver is bound further out than the closure it sits in
+	// writes that receiver's name across the closures in between, so those
+	// closures must not be given parameters that hide it.
+	t.Run("testingrunacross", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-testing-run")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "testingrunacross")
+	})
+
 	// Every name the rewrite writes has to still mean what the import list
 	// says where it is written, or the site is declined.
 	t.Run("testingrunshadow", func(t *testing.T) {

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -141,6 +141,14 @@ type runSite struct {
 	lexParent *runSite
 	outer     *runSite
 
+	// namedAcross is set when a site nested inside this one writes a receiver
+	// bound outside it, so that this site's own parameter must not hide that
+	// receiver. keep holds the names from the source that must survive; the
+	// names this plan introduces are handled by walking the enclosing sites,
+	// whose parameters are already named by then.
+	namedAcross bool
+	keep        []string
+
 	// tName is the name the rewrite gives this site's closure parameter, and
 	// recvText what it writes in front of .Run.
 	tName    string
@@ -191,6 +199,7 @@ func (a *analyzer) planTestingRun(pass *analysis.Pass, file *ast.File, root ast.
 	}
 	plan.origins = collectQtCOrigins(pass, root)
 	plan.collect(pass, root, nil)
+	plan.nameParams(pass)
 	plan.resolve(pass, a.onlyStableFixes)
 	plan.dropInfeasible(pass)
 	return plan
@@ -213,7 +222,6 @@ func (p *runPlan) collect(pass *analysis.Pass, n ast.Node, lexParent *runSite) {
 			call:      call,
 			lexParent: lexParent,
 			outer:     bindingSite(lexParent, run.recvObj),
-			tName:     freeName("t", takenNames(run.lit, p.qtAlias, p.testingName)),
 		}
 		p.sites = append(p.sites, site)
 
@@ -234,6 +242,61 @@ func bindingSite(lexParent *runSite, obj types.Object) *runSite {
 		}
 	}
 	return nil
+}
+
+// nameParams gives every site the name its rewrite will write for the closure
+// parameter it introduces.
+//
+// A new parameter is kept clear of every identifier already inside the closure
+// it belongs to, and that is enough on its own only while each site's receiver
+// is bound by the closure directly around it. A site whose receiver is bound
+// further out writes that receiver's name across the closures in between, and
+// those closures are taking parameters of their own from this same plan. Three
+// levels of c.Run where the middle one renames its *qt.C leaves the innermost
+// site writing a "t" that the middle rewrite has just introduced, so the call
+// binds to the middle subtest instead of the outer one. Both spellings compile
+// and both pass; only the subtest's name moves, from outer/deep to
+// outer/middle/deep, and with it every -run filter aimed at it.
+//
+// Only a site that is written across is kept clear of its enclosing names. A
+// plain nest wants the shadowing — it is what lets each level of
+// t.Run(…, func(t *testing.T)) call itself t.
+//
+// Two kinds of name are written across such a site. One is the parameter an
+// enclosing site is about to introduce, which is why the sites are named
+// outermost first: an enclosing name is final before an inner one is chosen.
+// The other is a name from the source, written by a site whose receiver came
+// from a c := qt.New(t) rather than from an enclosing closure; that one is
+// known before any naming and is collected first.
+func (p *runPlan) nameParams(pass *analysis.Pass) {
+	for _, s := range p.sites {
+		if s.outer != nil {
+			for x := s.lexParent; x != nil && x != s.outer; x = x.lexParent {
+				x.namedAcross = true
+			}
+			continue
+		}
+		name, ok := targetFromQtNew(pass, p.origins, s.run)
+		if !ok {
+			continue
+		}
+		for x := s.lexParent; x != nil; x = x.lexParent {
+			x.keep = append(x.keep, name)
+		}
+	}
+
+	for _, s := range p.sites {
+		taken := takenNames(s.run.lit, p.qtAlias, p.testingName)
+		for _, name := range s.keep {
+			taken[name] = true
+		}
+		if s.namedAcross {
+			for x := s.lexParent; x != nil; x = x.lexParent {
+				taken[x.tName] = true
+			}
+		}
+		s.tName = freeName("t", taken)
+	}
 }
 
 // resolve decides which sites are reported and which of those get edits.

--- a/testdata/src/testingrunacross/testingrunacross.go
+++ b/testdata/src/testingrunacross/testingrunacross.go
@@ -1,0 +1,89 @@
+// Package testingrunacross is the fixture for a c.Run whose receiver is bound
+// further out than the closure it sits in.
+//
+// The rewrite gives each closure a *testing.T parameter, and a site writes the
+// name of the parameter its receiver's closure is given. When the two are the
+// same closure the name is chosen against that closure's own identifiers and
+// nothing else can hide it. When they are not, the name is written across the
+// closures in between, and those are getting parameters from the same plan: a
+// parameter introduced in between hides the one that was meant. Both spellings
+// compile and both pass, so the only thing that moves is the subtest's name.
+package testingrunacross
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Three levels, where the middle closure renames its own *qt.C so that c in
+// its body still means the outer one. Naming the middle closure's parameter t
+// as well would leave "deep" reading the middle subtest's t, and the subtest
+// would move from outer/deep to outer/middle/deep.
+func TestGrandparentReceiver(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Run("middle", func(mid *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			mid.Assert(0, qt.Equals, 0)
+			c.Run("deep", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+				c.Assert(1, qt.Equals, 1)
+			})
+		})
+	})
+}
+
+// Four levels, so that two closures sit between the receiver and the site that
+// names it. Keeping only the closest one clear of the outer name is not
+// enough: the second would then be free to take that name back.
+func TestGreatGrandparentReceiver(t *testing.T) {
+	c := qt.New(t)
+	c.Run("l1", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Run("l2", func(m2 *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			m2.Assert(0, qt.Equals, 0)
+			c.Run("l3", func(m3 *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+				m3.Assert(0, qt.Equals, 0)
+				c.Run("deep", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+					c.Assert(1, qt.Equals, 1)
+				})
+			})
+		})
+	})
+}
+
+// The name written across an intermediate closure need not come from this
+// plan. Here "deep" runs on a *qt.C made by its own qt.New, so the rewrite
+// writes the test function's own t across the closure in between, and that
+// closure must not be given a parameter called t either. Without that, "deep"
+// moves two levels, from A/X plus a sibling deep to A/X/deep.
+//
+// The two closures both end up called t2, which is allowed to look odd: X is
+// kept clear of t because a site inside it writes t, and of nothing else,
+// because nothing inside it writes A's parameter. Keeping it clear of every
+// enclosing name as well is the change that costs every plain nest its t.
+func TestSourceNameAcross(t *testing.T) {
+	c := qt.New(t)
+	c.Run("A", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		d := qt.New(t)
+		c.Run("X", func(mid *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			mid.Assert(0, qt.Equals, 0)
+			d.Run("deep", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+				c.Assert(1, qt.Equals, 1)
+			})
+		})
+	})
+}
+
+// The acceptance control. Nothing is written across anything here, so every
+// closure keeps the plain t: shadowing is what makes a nest of
+// t.Run(…, func(t *testing.T)) read the way Go tests are written, and a rule
+// that renamed unconditionally would take that away from every nest to fix the
+// few that need it.
+func TestPlainNestKeepsT(t *testing.T) {
+	c := qt.New(t)
+	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(0, qt.Equals, 0)
+		c.Run("inner", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}

--- a/testdata/src/testingrunacross/testingrunacross.go.golden
+++ b/testdata/src/testingrunacross/testingrunacross.go.golden
@@ -1,0 +1,93 @@
+// Package testingrunacross is the fixture for a c.Run whose receiver is bound
+// further out than the closure it sits in.
+//
+// The rewrite gives each closure a *testing.T parameter, and a site writes the
+// name of the parameter its receiver's closure is given. When the two are the
+// same closure the name is chosen against that closure's own identifiers and
+// nothing else can hide it. When they are not, the name is written across the
+// closures in between, and those are getting parameters from the same plan: a
+// parameter introduced in between hides the one that was meant. Both spellings
+// compile and both pass, so the only thing that moves is the subtest's name.
+package testingrunacross
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Three levels, where the middle closure renames its own *qt.C so that c in
+// its body still means the outer one. Naming the middle closure's parameter t
+// as well would leave "deep" reading the middle subtest's t, and the subtest
+// would move from outer/deep to outer/middle/deep.
+func TestGrandparentReceiver(t *testing.T) {
+	t.Run("outer", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Run("middle", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			mid := qt.New(t2)
+			mid.Assert(0, qt.Equals, 0)
+			t.Run("deep", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+				c := qt.New(t)
+				c.Assert(1, qt.Equals, 1)
+			})
+		})
+	})
+}
+
+// Four levels, so that two closures sit between the receiver and the site that
+// names it. Keeping only the closest one clear of the outer name is not
+// enough: the second would then be free to take that name back.
+func TestGreatGrandparentReceiver(t *testing.T) {
+	t.Run("l1", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Run("l2", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			m2 := qt.New(t2)
+			m2.Assert(0, qt.Equals, 0)
+			t.Run("l3", func(t3 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+				m3 := qt.New(t3)
+				m3.Assert(0, qt.Equals, 0)
+				t.Run("deep", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+					c := qt.New(t)
+					c.Assert(1, qt.Equals, 1)
+				})
+			})
+		})
+	})
+}
+
+// The name written across an intermediate closure need not come from this
+// plan. Here "deep" runs on a *qt.C made by its own qt.New, so the rewrite
+// writes the test function's own t across the closure in between, and that
+// closure must not be given a parameter called t either. Without that, "deep"
+// moves two levels, from A/X plus a sibling deep to A/X/deep.
+//
+// The two closures both end up called t2, which is allowed to look odd: X is
+// kept clear of t because a site inside it writes t, and of nothing else,
+// because nothing inside it writes A's parameter. Keeping it clear of every
+// enclosing name as well is the change that costs every plain nest its t.
+func TestSourceNameAcross(t *testing.T) {
+	t.Run("A", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t2.Run("X", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			mid := qt.New(t2)
+			mid.Assert(0, qt.Equals, 0)
+			t.Run("deep", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+				c := qt.New(t)
+				c.Assert(1, qt.Equals, 1)
+			})
+		})
+	})
+}
+
+// The acceptance control. Nothing is written across anything here, so every
+// closure keeps the plain t: shadowing is what makes a nest of
+// t.Run(…, func(t *testing.T)) read the way Go tests are written, and a rule
+// that renamed unconditionally would take that away from every nest to fix the
+// few that need it.
+func TestPlainNestKeepsT(t *testing.T) {
+	t.Run("outer", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(0, qt.Equals, 0)
+		t.Run("inner", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+			c := qt.New(t)
+			c.Assert(1, qt.Equals, 1)
+		})
+	})
+}


### PR DESCRIPTION
Closes #56. Stacked on #61 (`fix/57-source-order`) — review that one first.

## What was wrong

A `c.Run` whose receiver is bound further out than the closure it sits in writes that receiver's name *across* the closures in between, and those closures are taking parameters from the same plan. `freeName` keeps a new parameter clear of the identifiers already inside its own closure, which says nothing about the ones this plan is about to introduce, so every level was free to take the name `t`.

## Measured against `frankban/quicktest v1.14.6`

The three shapes in the new fixture, `go test -v` before `-fix` and after, using a `v1.8.1` binary:

```
outer/deep          ->  outer/middle/deep
l1/l3, l1/deep      ->  l1/l2/l3, l1/l2/l3/deep
A/X, deep           ->  A/X, A/X/deep
```

Each still compiles and still passes; only the subtest's name moves, which breaks every `-run` filter aimed at it.

With this branch, the 16 `=== RUN` lines the fixture produces are byte-identical before and after `-fix` (`diff` exit 0), including the issue's own input:

```
=== RUN   TestGrandparentReceiver/outer/deep     (before -fix and after)
```

## Why not decline

The report suggests declining a site whose `s.outer.tName` is shadowed by a fixed intermediate, and that does restore the tree — I reproduced that. Two reasons this branch names the closures instead:

1. **The third shape has no `outer` at all.** In `TestSourceNameAcross` the receiver comes from its own `d := qt.New(t)`, so `bindingSite` returns nil and the name written across is the test function's own `t`. A rule keyed on `s.outer.tName` cannot see it. On `v1.8.1` that one moves *two* levels, from a sibling `deep` to `A/X/deep`, which is worse than the reported case and is not in the report.
2. **Declining costs the diagnostic, not just the fix.** A site with no fix is not reported at all, by this rule's stated policy. Naming the closures keeps both.

Keeping every closure clear of every enclosing name — the other option the report mentions — would cost each plain nest its `t`, which is what makes a nest of `t.Run(name, func(t *testing.T))` read the way Go tests are written. So only a closure that a name is written across is kept clear of it, and `TestPlainNestKeepsT` plus the existing `TestNested` are the acceptance controls for that: both still produce `t` at every level, and their goldens are unchanged by this branch.

## Mutants

Two, both compiling, both `go vet` clean, both failing for the intended reason.

**M1 — "only the closest enclosing name can collide":** `taken[s.lexParent.tName] = true` instead of walking the ancestor chain.

```
$ go build ./... && go vet ./...   # 0, 0
$ go test ./... -count=1
--- FAIL: TestFixes/testingrunacross
  -  t.Run("l3", func(t *testing.T)     <- mutant
  +  t.Run("l3", func(t3 *testing.T)    <- golden
exit 1
```

The second intermediate takes the outer name back. Built as a binary and run against the real library:

```
=== RUN   TestGreatGrandparentReceiver/l1/deep      (correct)
=== RUN   TestGreatGrandparentReceiver/l1/l3/deep   (mutant)
```

**M2 — "the site that writes a name across is the one that needs a distinct parameter":** mark `s.namedAcross` on the binding site rather than on the closures it writes across.

```
$ go build ./... && go vet ./...   # 0, 0
$ go test ./... -count=1
--- FAIL: TestFixes/testingrunacross
exit 1
```

Against the real library:

```
outer/deep          ->  outer/middle/deep
l1/l3, l1/deep      ->  l1/l2/l3, l1/l2/deep
```

Reverted, `go test ./... -count=1` is exit 0 in both cases.

## The fixture is not vacuous

Run against the unfixed `requiretestingrun.go`, `TestFixes/testingrunacross` fails: the produced text has `func(t *testing.T)` at every level where the golden wants `t2` and `t3`. And with a `v1.8.1` binary, `-fix` moves 4 of the fixture's 16 subtest names.

`TestGoldenFilesCompile` stages the new golden — verified by appending an undefined symbol to it and watching that test report `undefined: undefinedSymbolProbe`, then reverting.

## Docs

The `-require-testing-run` section of `README.md` gains a paragraph for this; the "nested subtests" paragraph next to it described only the direct-parent route.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./... -count=1`, `golangci-lint run ./...` all exit 0. `go mod tidy` then `git diff --exit-code go.mod go.sum` exits 0.