### PR TITLE
feat: make -tags reach the package loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ qtlint -fix -only-stable-fixes ./...
 qtlint -require-qt-c-receiver ./...
 qtlint -fix -require-qt-c-receiver ./...
 qtlint -fix -require-testing-run ./...
+
+# Include packages and files behind a build constraint
+qtlint -tags integration ./...
+qtlint -tags integration,e2e ./...
 ```
 
 ### With golangci-lint
@@ -126,6 +130,24 @@ Then run with auto-fix:
 ```bash
 golangci-lint run --fix
 ```
+
+### `-tags` flag
+
+Go source behind a build constraint is not part of the default build, so `qtlint ./...` does not see it. Pass `-tags` to name the constraints to satisfy, exactly as you would to `go build`:
+
+```bash
+qtlint -tags integration ./...        # one tag
+qtlint -tags integration,e2e ./...    # several, comma separated
+qtlint -tags 'integration e2e' ./...  # the older space separated spelling
+```
+
+Both multi-value spellings are accepted because the `go` command accepts both, and a repeated `-tags` replaces the previous value rather than adding to it — again matching `go build`.
+
+This matters most on a recursive pattern. A package whose files are all excluded by a build constraint is not an error, it is simply absent, so without `-tags` the command reports nothing about it and still exits 0. Tagged test files sitting next to untagged source disappear the same way, and just as quietly.
+
+Note for anyone who reached for `go vet` instead: `go vet -tags integration -vettool=$(which qtlint) ./...` has always worked, because in that mode `go vet` loads the packages itself. It is still supported and reports the same diagnostics; you no longer need it just to get build tags.
+
+One limitation: `-tags` is forwarded through `GOFLAGS` to the `go` command that loads the packages. A custom `GOPACKAGESDRIVER` does not run the `go` command and so will not see it.
 
 ### `-only-stable-fixes` flag
 

--- a/cmd/qtlint/main.go
+++ b/cmd/qtlint/main.go
@@ -13,6 +13,10 @@
 //
 //	# Analyze specific packages
 //	qtlint ./...
+//
+//	# Analyze packages and files behind a build constraint
+//	qtlint -tags integration ./...
+//	qtlint -tags integration,e2e ./...
 package main
 
 import (
@@ -23,6 +27,7 @@ import (
 	"golang.org/x/tools/go/analysis/singlechecker"
 
 	"github.com/go-extras/qtlint"
+	"github.com/go-extras/qtlint/internal/tagsflag"
 )
 
 // Build information. Populated at build-time via ldflags.
@@ -43,6 +48,21 @@ func main() {
 
 	// Add custom version flag.
 	flag.Bool("version", false, "print version and exit")
+
+	// The analysis driver accepts -tags but does nothing with it, and it never
+	// hands out the package-loading configuration where build tags would
+	// belong. Put them where the go command that go/packages runs will read
+	// them, before the driver starts loading. See package tagsflag.
+	if goflags, ok := tagsflag.Forward(os.Args[1:], os.Getenv("GOFLAGS")); ok {
+		if err := os.Setenv("GOFLAGS", goflags); err != nil {
+			fmt.Fprintf(os.Stderr, "qtlint: cannot forward -tags through GOFLAGS: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// The driver documents its own -tags shim as having no effect. It does
+	// have one here, so correct that line on its way out.
+	flag.CommandLine.SetOutput(tagsflag.UsageWriter(os.Stderr))
 
 	singlechecker.Main(qtlint.Analyzer)
 }

--- a/cmd/qtlint/tags_test.go
+++ b/cmd/qtlint/tags_test.go
@@ -1,0 +1,292 @@
+// Package main_test drives the qtlint command as a program.
+//
+// The -tags wiring under test lives in main and only has an observable effect
+// on the go command that the analysis driver runs to load packages, so nothing
+// short of building the binary and running it against a module can see whether
+// the flag arrived. The fixture module in testdata/tagsmod carries the two
+// shapes a build constraint takes: a package that still loads without the tag
+// while its constrained test file is dropped, and a package that disappears
+// from a recursive pattern entirely.
+package main_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// fixtureDir is the module the command is run against, relative to this
+// package's directory.
+const fixtureDir = "testdata/tagsmod"
+
+// qtlintBin is the command under test, built once by TestMain.
+var qtlintBin string
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	dir, err := os.MkdirTemp("", "qtlint-tags")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "temp dir: %v\n", err)
+
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	qtlintBin = filepath.Join(dir, "qtlint")
+	if runtime.GOOS == "windows" {
+		qtlintBin += ".exe"
+	}
+
+	if out, err := exec.Command("go", "build", "-o", qtlintBin, ".").CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "build qtlint: %v\n%s", err, out)
+
+		return 1
+	}
+
+	return m.Run()
+}
+
+// TestTagsReachesTheLoader is the test that separates a -tags flag which is
+// merely accepted from one that is honored. Every row is a spelling the go
+// command itself accepts, and the wanted files are the ones "go list" reports
+// as belonging to the build for that spelling.
+func TestTagsReachesTheLoader(t *testing.T) {
+	t.Parallel()
+
+	const (
+		plain  = "plain/plain_test.go"
+		quiet  = "quiet/quiet_test.go"
+		hidden = "hidden/hidden_test.go"
+		alpha  = "alpha/alpha_test.go"
+		beta   = "beta/beta_test.go"
+	)
+
+	tests := []struct {
+		name string
+		env  []string
+		args []string
+		want []string
+	}{{
+		// The acceptance control. Without it every row below is satisfied by
+		// a fix that simply satisfies every build constraint.
+		name: "no tag leaves constrained files out of the build",
+		args: []string{"./..."},
+		want: []string{plain},
+	}, {
+		name: "space separated value",
+		args: []string{"-tags", "qtprobe", "./..."},
+		want: []string{hidden, plain, quiet},
+	}, {
+		name: "value joined with equals",
+		args: []string{"-tags=qtprobe", "./..."},
+		want: []string{hidden, plain, quiet},
+	}, {
+		name: "two leading dashes",
+		args: []string{"--tags=qtprobe", "./..."},
+		want: []string{hidden, plain, quiet},
+	}, {
+		name: "comma separated multi value",
+		args: []string{"-tags", "qtalpha,qtbeta", "./..."},
+		want: []string{alpha, beta, plain},
+	}, {
+		// The spelling go kept for compatibility with Go 1.12 and earlier.
+		name: "space separated multi value",
+		args: []string{"-tags", "qtalpha qtbeta", "./..."},
+		want: []string{alpha, beta, plain},
+	}, {
+		// go's own -tags replaces on repeat rather than accumulating.
+		name: "a repeated flag takes the last value",
+		args: []string{"-tags", "qtalpha", "-tags", "qtbeta", "./..."},
+		want: []string{beta, plain},
+	}, {
+		// -c takes a separate value, so a scan that stopped at the first
+		// argument it could not classify would never reach -tags.
+		name: "after another flag that takes a separate value",
+		args: []string{"-c", "0", "-tags", "qtprobe", "./..."},
+		want: []string{hidden, plain, quiet},
+	}, {
+		name: "a package named explicitly rather than by pattern",
+		args: []string{"-tags", "qtprobe", "./hidden/"},
+		want: []string{hidden},
+	}, {
+		// An inherited GOFLAGS must not be thrown away by a command line that
+		// says nothing about tags.
+		name: "no flag keeps the tags already in GOFLAGS",
+		env:  []string{"GOFLAGS=-tags=qtprobe"},
+		args: []string{"./..."},
+		want: []string{hidden, plain, quiet},
+	}, {
+		// ...and must lose to a command line that does, which is the
+		// precedence the go command gives an explicit flag.
+		name: "the flag beats the tags already in GOFLAGS",
+		env:  []string{"GOFLAGS=-tags=qtalpha"},
+		args: []string{"-tags", "qtprobe", "./..."},
+		want: []string{hidden, plain, quiet},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := runQtlint(t, tc.env, tc.args...)
+			if !slices.Equal(got.files, tc.want) {
+				t.Errorf("reported files\ngot:  %q\nwant: %q\noutput:\n%s", got.files, tc.want, got.output)
+			}
+		})
+	}
+}
+
+// TestRecursivePatternDoesNotPassSilently pins the failure shape that hid the
+// defect: on a recursive pattern a package excluded by a build constraint is
+// not an error, it is simply absent, so the command reports nothing and exits
+// 0 having inspected nothing behind the tag.
+func TestRecursivePatternDoesNotPassSilently(t *testing.T) {
+	t.Parallel()
+
+	got := runQtlint(t, nil, "-tags", "qtprobe", "./quiet/...")
+
+	if len(got.files) == 0 {
+		t.Errorf("reported nothing behind the tag; output:\n%s", got.output)
+	}
+	if got.code == 0 {
+		t.Errorf("exit code = 0 with a violation behind the tag; output:\n%s", got.output)
+	}
+}
+
+// TestMatchesVetTool checks the standalone command against the same analyzer
+// driven by "go vet -vettool", which loads packages itself and has always
+// applied -tags. The two must see the same files.
+func TestMatchesVetTool(t *testing.T) {
+	t.Parallel()
+
+	standalone := runQtlint(t, nil, "-tags", "qtprobe", "./...")
+	vet := runCommand(t, nil, "go", "vet", "-tags", "qtprobe", "-vettool="+qtlintBin, "./...")
+
+	if !slices.Equal(standalone.files, vet.files) {
+		t.Errorf("standalone and vettool disagree\nstandalone: %q\nvettool:    %q", standalone.files, vet.files)
+	}
+	if len(vet.files) == 0 {
+		t.Fatalf("vettool control reported nothing, so it proves nothing; output:\n%s", vet.output)
+	}
+}
+
+// TestHelpDescribesTags checks that -h says what -tags does. The driver
+// registers the flag as a deprecated shim documented as having no effect,
+// which would send a reader to "go vet -vettool" for something this command
+// now does on its own.
+func TestHelpDescribesTags(t *testing.T) {
+	t.Parallel()
+
+	got := runQtlint(t, nil, "-h")
+
+	const want = "  -tags string\n    \ta comma-separated list of build tags"
+	if !strings.Contains(got.output, want) {
+		t.Errorf("help does not describe -tags\nwant substring: %q\ngot:\n%s", want, got.output)
+	}
+	// Other shims keep their wording, so this looks only at the -tags entry.
+	if strings.Contains(got.output, "  -tags string\n    \tno effect") {
+		t.Errorf("help still calls -tags inert:\n%s", got.output)
+	}
+}
+
+// result is what one run of a command reported.
+type result struct {
+	// files are the fixture-relative paths named by diagnostics, sorted and
+	// deduplicated.
+	files []string
+	// code is the process exit code.
+	code int
+	// output is stdout and stderr, for failure messages.
+	output string
+}
+
+func runQtlint(t *testing.T, env []string, args ...string) result {
+	t.Helper()
+
+	return runCommand(t, env, qtlintBin, args...)
+}
+
+func runCommand(t *testing.T, env []string, name string, args ...string) result {
+	t.Helper()
+
+	dir := fixturePath(t)
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	// GOFLAGS is the channel the fix writes to, so a value inherited from the
+	// developer's shell would decide these results instead of the flag under
+	// test. GOWORK keeps an ambient workspace from claiming the fixture
+	// module. Entries appended later win, so a row's own env overrides these.
+	cmd.Env = append(os.Environ(), "GOFLAGS=", "GOWORK=off")
+	cmd.Env = append(cmd.Env, env...)
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	code := 0
+	err := cmd.Run()
+
+	var exitErr *exec.ExitError
+	switch {
+	case errors.As(err, &exitErr):
+		code = exitErr.ExitCode()
+	case err != nil:
+		t.Fatalf("run %s %q: %v\n%s", name, args, err, out.String())
+	}
+
+	return result{files: diagnosedFiles(dir, out.String()), code: code, output: out.String()}
+}
+
+// diagnosedFiles extracts the fixture-relative file of every diagnostic in
+// output. The standalone command prints absolute paths and go vet prints paths
+// relative to the module, so both are resolved against dir.
+func diagnosedFiles(dir, output string) []string {
+	files := make([]string, 0)
+
+	for _, line := range strings.Split(output, "\n") {
+		const ext = ".go"
+
+		i := strings.Index(line, ext+":")
+		if i < 0 {
+			continue
+		}
+
+		path := line[:i+len(ext)]
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(dir, path)
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue
+		}
+
+		files = append(files, filepath.ToSlash(rel))
+	}
+
+	slices.Sort(files)
+
+	return slices.Compact(files)
+}
+
+func fixturePath(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.Abs(fixtureDir)
+	if err != nil {
+		t.Fatalf("locate %s: %v", fixtureDir, err)
+	}
+
+	return dir
+}

--- a/cmd/qtlint/testdata/tagsmod/alpha/alpha.go
+++ b/cmd/qtlint/testdata/tagsmod/alpha/alpha.go
@@ -1,0 +1,4 @@
+package alpha
+
+// Name keeps this package loadable when the tagged test file is excluded.
+const Name = "alpha"

--- a/cmd/qtlint/testdata/tagsmod/alpha/alpha_test.go
+++ b/cmd/qtlint/testdata/tagsmod/alpha/alpha_test.go
@@ -1,0 +1,15 @@
+//go:build qtalpha
+
+package alpha
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func Testalpha(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/tagsmod/beta/beta.go
+++ b/cmd/qtlint/testdata/tagsmod/beta/beta.go
@@ -1,0 +1,4 @@
+package beta
+
+// Name keeps this package loadable when the tagged test file is excluded.
+const Name = "beta"

--- a/cmd/qtlint/testdata/tagsmod/beta/beta_test.go
+++ b/cmd/qtlint/testdata/tagsmod/beta/beta_test.go
@@ -1,0 +1,15 @@
+//go:build qtbeta
+
+package beta
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func Testbeta(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/tagsmod/go.mod
+++ b/cmd/qtlint/testdata/tagsmod/go.mod
@@ -1,0 +1,11 @@
+// This module is a fixture for the -tags end-to-end test. It lives under
+// testdata so the go tool never walks into it from the qtlint module, and it
+// replaces quicktest with a local stub so it resolves with no network and no
+// go.sum.
+module qtlint.test/tagsmod
+
+go 1.21
+
+require github.com/frankban/quicktest v0.0.0
+
+replace github.com/frankban/quicktest => ./quicktest

--- a/cmd/qtlint/testdata/tagsmod/hidden/hidden.go
+++ b/cmd/qtlint/testdata/tagsmod/hidden/hidden.go
@@ -1,0 +1,7 @@
+//go:build qtprobe
+
+package hidden
+
+// Name is the only non-test declaration, and it is constrained too, so the
+// whole package vanishes from ./... unless the tag is set.
+const Name = "hidden"

--- a/cmd/qtlint/testdata/tagsmod/hidden/hidden_test.go
+++ b/cmd/qtlint/testdata/tagsmod/hidden/hidden_test.go
@@ -1,0 +1,15 @@
+//go:build qtprobe
+
+package hidden
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestHidden(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/tagsmod/plain/plain.go
+++ b/cmd/qtlint/testdata/tagsmod/plain/plain.go
@@ -1,0 +1,4 @@
+package plain
+
+// Name keeps this package non-empty without a build constraint.
+const Name = "plain"

--- a/cmd/qtlint/testdata/tagsmod/plain/plain_test.go
+++ b/cmd/qtlint/testdata/tagsmod/plain/plain_test.go
@@ -1,0 +1,13 @@
+package plain
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPlain(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/tagsmod/quicktest/go.mod
+++ b/cmd/qtlint/testdata/tagsmod/quicktest/go.mod
@@ -1,0 +1,3 @@
+module github.com/frankban/quicktest
+
+go 1.21

--- a/cmd/qtlint/testdata/tagsmod/quicktest/quicktest.go
+++ b/cmd/qtlint/testdata/tagsmod/quicktest/quicktest.go
@@ -1,0 +1,39 @@
+// Package quicktest is a stub for the -tags end-to-end fixture. It is not the
+// real quicktest package and declares only what the fixture files below it
+// need to type-check.
+package quicktest
+
+import "testing"
+
+// C is a quicktest checker.
+type C struct {
+	TB testing.TB
+}
+
+// New returns a new checker instance.
+func New(t testing.TB) *C {
+	return &C{TB: t}
+}
+
+// Assert runs the given check and stops execution in case of failure.
+func (c *C) Assert(got any, checker Checker, args ...any) bool {
+	return true
+}
+
+// Checker is the interface implemented by quicktest checkers.
+type Checker interface {
+	Check(got any, args []any) error
+}
+
+type checkerFunc struct{}
+
+func (checkerFunc) Check(got any, args []any) error { return nil }
+
+// IsNil checks that a value is nil.
+var IsNil Checker = checkerFunc{}
+
+// IsNotNil checks that a value is not nil.
+var IsNotNil Checker = checkerFunc{}
+
+// Not negates a checker.
+func Not(c Checker) Checker { return c }

--- a/cmd/qtlint/testdata/tagsmod/quiet/quiet.go
+++ b/cmd/qtlint/testdata/tagsmod/quiet/quiet.go
@@ -1,0 +1,5 @@
+package quiet
+
+// Name keeps this package loadable when the tagged test file is excluded, so
+// that excluding the test file produces no error of any kind.
+const Name = "quiet"

--- a/cmd/qtlint/testdata/tagsmod/quiet/quiet_test.go
+++ b/cmd/qtlint/testdata/tagsmod/quiet/quiet_test.go
@@ -1,0 +1,15 @@
+//go:build qtprobe
+
+package quiet
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestQuiet(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/internal/tagsflag/tagsflag.go
+++ b/internal/tagsflag/tagsflag.go
@@ -1,0 +1,217 @@
+// Package tagsflag makes the qtlint command's -tags flag real.
+//
+// The analysis driver qtlint is built on,
+// golang.org/x/tools/go/analysis/singlechecker, registers -tags itself: not as
+// a build-tag flag, but as one of a handful of inert shims kept so that scripts
+// written for older releases of "go vet" keep parsing. Its registered usage
+// text is literally "no effect (deprecated)", and the value it parses is
+// discarded. The driver then loads packages through go/packages with a
+// configuration it never exposes, so a caller of singlechecker.Main has no way
+// to put the tags on packages.Config.BuildFlags.
+//
+// What go/packages does expose is the go command it shells out to, and the go
+// command reads build flags from the GOFLAGS environment variable. Writing the
+// requested tags there is therefore the one channel that reaches the loader
+// without replacing the driver, and replacing the driver would cost qtlint the
+// behavior that comes with it: -fix, -diff, -json, -c, the -flags inventory
+// that "go vet -vettool" reads, and the .cfg dispatch that makes qtlint usable
+// as a vet tool in the first place.
+//
+// The one input this cannot reach is a custom GOPACKAGESDRIVER, which does not
+// run the go command and so never sees GOFLAGS.
+package tagsflag
+
+import (
+	"bytes"
+	"io"
+	"strings"
+)
+
+// name is the command-line flag this package forwards.
+const name = "tags"
+
+// Forward returns the GOFLAGS value that makes the go command satisfy the build
+// tags requested on the command line in args, starting from the current GOFLAGS
+// value in goflags.
+//
+// It reports false when args carry no -tags flag at all. A caller that is given
+// false must leave GOFLAGS exactly as it found it: an inherited GOFLAGS may
+// already carry a -tags setting the user meant to keep, and overwriting it with
+// an empty one would take away build tags that plain "qtlint ./..." honors
+// today.
+func Forward(args []string, goflags string) (string, bool) {
+	value, ok := lastValue(args)
+	if !ok {
+		return "", false
+	}
+
+	entry := "-" + name + "=" + strings.Join(forwardable(Split(value)), ",")
+	if goflags == "" {
+		return entry, true
+	}
+
+	// The go command applies GOFLAGS entries left to right and a repeated
+	// -tags replaces rather than extends, so the last entry wins. Appending
+	// is what lets an explicit -tags on the qtlint command line beat an
+	// inherited GOFLAGS, which is the precedence the go command itself gives
+	// a flag written on the command line.
+	return goflags + " " + entry, true
+}
+
+// Split splits a -tags flag value into build tags the way the go command does.
+//
+// A value containing a space or a quote is split on whitespace, which is the
+// spelling the go command still accepts for compatibility with Go 1.12 and
+// earlier. Every other value is split on commas, dropping empty entries. Both
+// spellings reach the same set of tags: "go build -tags a,b" and
+// "go build -tags 'a b'" are the same request.
+func Split(value string) []string {
+	if strings.ContainsAny(value, " \t'\"") {
+		return strings.Fields(value)
+	}
+
+	tags := make([]string, 0, strings.Count(value, ",")+1)
+	for _, tag := range strings.Split(value, ",") {
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+
+	return tags
+}
+
+// forwardable drops the tags that the GOFLAGS encoding cannot carry.
+//
+// GOFLAGS is split on spaces and has no quoting, so the whole setting has to
+// travel as one comma-separated word. A tag holding a space, a
+// comma or a quote cannot survive that, and it could not have been satisfied
+// either: a build constraint names its tags in the identifier alphabet, so the
+// go command would have carried such a tag along and never matched it. Dropping
+// it here reaches the same set of files, and keeps GOFLAGS free of the quotes
+// the go command would not have unquoted anyway.
+func forwardable(tags []string) []string {
+	kept := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		if !strings.ContainsAny(tag, " \t,'\"") {
+			kept = append(kept, tag)
+		}
+	}
+
+	return kept
+}
+
+// lastValue returns the value of the last -tags flag in args, matching the go
+// command's rule that a repeated -tags replaces the previous setting rather
+// than adding to it.
+//
+// The scan is deliberately blind to how many arguments each flag takes. The
+// driver's flag set is the authority on that, and it does not exist until the
+// driver parses, which is after the point where GOFLAGS still matters. So every
+// argument up to a bare "--" is examined. A package pattern never begins with a
+// dash, so the only argument this can misread is a literal "-tags" written as
+// the value of some other flag.
+func lastValue(args []string) (string, bool) {
+	var (
+		value string
+		found bool
+	)
+
+	for i := 0; i < len(args); i++ {
+		// The flag package stops parsing flags at a bare "--", so a -tags
+		// after it is a package pattern rather than a flag.
+		if args[i] == "--" {
+			break
+		}
+
+		trimmed, ok := trimDashes(args[i])
+		if !ok {
+			continue
+		}
+
+		flagName, inline, hasInline := strings.Cut(trimmed, "=")
+		if flagName != name {
+			continue
+		}
+
+		if hasInline {
+			value, found = inline, true
+
+			continue
+		}
+
+		// A trailing "-tags" with nothing after it is an error the driver
+		// reports for us; there is nothing to forward.
+		if i+1 < len(args) {
+			value, found = args[i+1], true
+			i++
+		}
+	}
+
+	return value, found
+}
+
+// trimDashes strips the leading dashes from arg and reports whether arg is
+// shaped like a flag at all. The flag package accepts one dash or two, and
+// treats "-", "--" and anything not starting with a dash as something other
+// than a flag.
+func trimDashes(arg string) (string, bool) {
+	if !strings.HasPrefix(arg, "-") {
+		return "", false
+	}
+
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(arg, "-"), "-")
+	if trimmed == "" || strings.HasPrefix(trimmed, "-") {
+		return "", false
+	}
+
+	return trimmed, true
+}
+
+// driverUsageHead is how the flag package renders the first line of the
+// driver's -tags shim: two spaces, the flag name, and the value placeholder.
+const driverUsageHead = "  -" + name + " string\n"
+
+// driverUsageMark appears in the shim's usage text and in no honest -tags
+// description, so requiring it keeps UsageWriter from rewriting a future
+// release of x/tools that has made -tags real by itself.
+const driverUsageMark = "no effect"
+
+// usageText is what -tags does in this command.
+const usageText = driverUsageHead +
+	"    \ta comma-separated list of build tags to consider satisfied, as with go build -tags\n"
+
+// UsageWriter returns a writer that forwards to w, correcting the -tags usage
+// line the analysis driver prints.
+//
+// The driver registers -tags as a deprecated shim and describes it as having no
+// effect. That description is wrong for this command, and a user who reads it
+// would reasonably conclude the flag is not worth passing. The flag package
+// renders each flag's usage with a single Write to the flag set's output, which
+// is what makes this correction possible; flag.CommandLine.SetOutput is the
+// supported way to redirect that output.
+//
+// If a future release of x/tools words the shim differently, or the flag
+// package stops writing one flag at a time, no line matches and the driver's
+// own text is printed unchanged. Everything else written to w is passed through
+// untouched.
+func UsageWriter(w io.Writer) io.Writer {
+	return &usageWriter{w: w}
+}
+
+type usageWriter struct {
+	w io.Writer
+}
+
+func (u *usageWriter) Write(p []byte) (int, error) {
+	if !bytes.HasPrefix(p, []byte(driverUsageHead)) || !bytes.Contains(p, []byte(driverUsageMark)) {
+		return u.w.Write(p)
+	}
+
+	if _, err := u.w.Write([]byte(usageText)); err != nil {
+		return 0, err
+	}
+
+	// Report the caller's own length: it wrote p, and a short count would
+	// read as an io.ErrShortWrite that never happened.
+	return len(p), nil
+}

--- a/internal/tagsflag/tagsflag_test.go
+++ b/internal/tagsflag/tagsflag_test.go
@@ -1,0 +1,261 @@
+package tagsflag_test
+
+import (
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-extras/qtlint/internal/tagsflag"
+)
+
+func TestSplit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{{
+		name:  "empty value carries no tags",
+		value: "",
+		want:  nil,
+	}, {
+		name:  "single tag",
+		value: "integration",
+		want:  []string{"integration"},
+	}, {
+		name:  "commas separate tags",
+		value: "integration,e2e",
+		want:  []string{"integration", "e2e"},
+	}, {
+		name:  "empty entries are dropped",
+		value: "integration,,e2e,",
+		want:  []string{"integration", "e2e"},
+	}, {
+		// The spelling go keeps for compatibility with Go 1.12 and earlier.
+		name:  "spaces separate tags",
+		value: "integration e2e",
+		want:  []string{"integration", "e2e"},
+	}, {
+		name:  "runs of space separate tags once",
+		value: "  integration   e2e  ",
+		want:  []string{"integration", "e2e"},
+	}, {
+		// A value holding a space takes go's space-splitting path whole, so a
+		// comma inside it stays part of the token and matches no constraint.
+		// Splitting on both would satisfy a tag go leaves unsatisfied.
+		name:  "a space makes the whole value space separated",
+		value: "integration, e2e",
+		want:  []string{"integration,", "e2e"},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tagsflag.Split(tc.value); !slices.Equal(got, tc.want) {
+				t.Errorf("Split(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestForward(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		goflags string
+		want    string
+		wantOK  bool
+	}{{
+		name:   "no tags flag leaves GOFLAGS alone",
+		args:   []string{"-fix", "./..."},
+		wantOK: false,
+	}, {
+		name:    "no tags flag does not disturb an inherited GOFLAGS",
+		args:    []string{"./..."},
+		goflags: "-tags=integration -mod=mod",
+		wantOK:  false,
+	}, {
+		name:   "value in the next argument",
+		args:   []string{"-tags", "integration", "./..."},
+		want:   "-tags=integration",
+		wantOK: true,
+	}, {
+		name:   "value joined with equals",
+		args:   []string{"-tags=integration", "./..."},
+		want:   "-tags=integration",
+		wantOK: true,
+	}, {
+		name:   "two leading dashes",
+		args:   []string{"--tags", "integration", "./..."},
+		want:   "-tags=integration",
+		wantOK: true,
+	}, {
+		name:   "comma separated value passes through",
+		args:   []string{"-tags", "integration,e2e", "./..."},
+		want:   "-tags=integration,e2e",
+		wantOK: true,
+	}, {
+		// GOFLAGS is split on spaces, so the space spelling has to be
+		// re-encoded with commas to survive the trip.
+		name:   "space separated value is re-encoded with commas",
+		args:   []string{"-tags", "integration e2e", "./..."},
+		want:   "-tags=integration,e2e",
+		wantOK: true,
+	}, {
+		// go's -tags replaces on repeat rather than accumulating.
+		name:   "a repeated flag takes the last value",
+		args:   []string{"-tags", "integration", "-tags=e2e", "./..."},
+		want:   "-tags=e2e",
+		wantOK: true,
+	}, {
+		name:    "an inherited GOFLAGS is kept and overridden",
+		args:    []string{"-tags", "integration", "./..."},
+		goflags: "-mod=mod -tags=stale",
+		want:    "-mod=mod -tags=stale -tags=integration",
+		wantOK:  true,
+	}, {
+		// A token that cannot reach GOFLAGS could not have matched a build
+		// constraint either, so dropping it lands on go's own outcome.
+		name:   "a token that cannot be a build tag is dropped",
+		args:   []string{"-tags", "integration, e2e", "./..."},
+		want:   "-tags=e2e",
+		wantOK: true,
+	}, {
+		name:   "a quoted value cannot name a tag and forwards none",
+		args:   []string{"-tags", "'integration e2e'", "./..."},
+		want:   "-tags=",
+		wantOK: true,
+	}, {
+		name:   "an explicitly empty value clears the tags",
+		args:   []string{"-tags=", "./..."},
+		want:   "-tags=",
+		wantOK: true,
+	}, {
+		name:   "a trailing tags flag has no value to forward",
+		args:   []string{"./...", "-tags"},
+		wantOK: false,
+	}, {
+		name:   "a flag terminator ends the scan",
+		args:   []string{"--", "-tags", "integration"},
+		wantOK: false,
+	}, {
+		name:   "a lone dash is not a flag",
+		args:   []string{"-", "-tags=integration"},
+		want:   "-tags=integration",
+		wantOK: true,
+	}, {
+		name:   "a differently named flag is not tags",
+		args:   []string{"-tagsx=integration", "-xtags=e2e", "./..."},
+		wantOK: false,
+	}, {
+		// The scan cannot know how many arguments each driver flag takes, so
+		// it keeps looking past arguments the flag package would have treated
+		// as the end of the flags. Setting GOFLAGS for a command line the
+		// driver will reject anyway costs nothing.
+		name:   "the scan continues past a non-flag argument",
+		args:   []string{"./...", "-tags", "integration"},
+		want:   "-tags=integration",
+		wantOK: true,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := tagsflag.Forward(tc.args, tc.goflags)
+			if ok != tc.wantOK {
+				t.Fatalf("Forward(%q, %q) ok = %v, want %v", tc.args, tc.goflags, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("Forward(%q, %q) = %q, want %q", tc.args, tc.goflags, got, tc.want)
+			}
+			if !ok && got != "" {
+				t.Errorf("Forward(%q, %q) = %q, want %q when not forwarding", tc.args, tc.goflags, got, "")
+			}
+		})
+	}
+}
+
+// driverTagsUsage is the chunk the flag package writes for the driver's -tags
+// shim: the whole entry arrives in one Write.
+const driverTagsUsage = "  -tags string\n    \tno effect (deprecated)\n"
+
+func TestUsageWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		chunk string
+		want  string
+	}{{
+		name:  "the driver's inert description is corrected",
+		chunk: driverTagsUsage,
+		want:  "  -tags string\n    \ta comma-separated list of build tags to consider satisfied, as with go build -tags\n",
+	}, {
+		// Other shims are the driver's business and keep their wording.
+		name:  "another deprecated shim is untouched",
+		chunk: "  -source\n    \tno effect (deprecated)\n",
+		want:  "  -source\n    \tno effect (deprecated)\n",
+	}, {
+		name:  "an unrelated flag entry is untouched",
+		chunk: "  -fix\n    \tapply all suggested fixes\n",
+		want:  "  -fix\n    \tapply all suggested fixes\n",
+	}, {
+		// Only the driver's inert wording is replaced, so a release of x/tools
+		// that made -tags real keeps its own description.
+		name:  "a -tags entry that does not claim to be inert is untouched",
+		chunk: "  -tags string\n    \tbuild tags to satisfy\n",
+		want:  "  -tags string\n    \tbuild tags to satisfy\n",
+	}, {
+		name:  "a parse error message is untouched",
+		chunk: "flag provided but not defined: -bogus\n",
+		want:  "flag provided but not defined: -bogus\n",
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got strings.Builder
+
+			n, err := tagsflag.UsageWriter(&got).Write([]byte(tc.chunk))
+			if err != nil {
+				t.Fatalf("Write(%q): %v", tc.chunk, err)
+			}
+			if n != len(tc.chunk) {
+				t.Errorf("Write(%q) = %d, want %d", tc.chunk, n, len(tc.chunk))
+			}
+			if got.String() != tc.want {
+				t.Errorf("Write(%q) wrote %q, want %q", tc.chunk, got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestUsageWriterReportsWriteErrors(t *testing.T) {
+	t.Parallel()
+
+	want := errors.New("no room")
+
+	_, err := tagsflag.UsageWriter(failingWriter{err: want}).Write([]byte(driverTagsUsage))
+	if !errors.Is(err, want) {
+		t.Errorf("Write error = %v, want %v", err, want)
+	}
+}
+
+type failingWriter struct {
+	err error
+}
+
+func (f failingWriter) Write([]byte) (int, error) {
+	return 0, f.err
+}
+
+// Interface check: UsageWriter's result is used where an io.Writer is wanted.
+var _ = func() io.Writer { return tagsflag.UsageWriter(io.Discard) }


### PR DESCRIPTION
## What was wrong

`-tags` appeared in `qtlint -h` and an undefined flag exited 2, so the flag was genuinely declared — but it never reached the package loader.

The flag is not qtlint's. `golang.org/x/tools/go/analysis/internal/analysisflags` registers it as one of a handful of inert shims kept so that scripts written for older releases of `go vet` keep parsing:

```go
// Add shims for legacy vet flags to enable existing
// scripts that run vet to continue to work.
_ = flag.Bool("source", false, "no effect (deprecated)")
_ = flag.Bool("v", false, "no effect (deprecated)")
_ = flag.Bool("all", false, "no effect (deprecated)")
_ = flag.String("tags", "", "no effect (deprecated)")
```

The value is parsed and discarded. `singlechecker.Main` then hands off to a driver that loads packages through `go/packages` with a `packages.Config` it never exposes, so a caller has nowhere to put `BuildFlags`.

Named explicitly, that failed loudly:

```
$ qtlint -tags integration ./loud/
-: build constraints exclude all Go files in .../loud
qtlint: analysis skipped due to errors in package
EXIT=1
```

On a recursive pattern it failed **quietly**, which is worse. A package whose files are all excluded by a build constraint is not an error, it is simply absent, and a tagged test file next to untagged source disappears the same way — so the command reported nothing and exited **0** having inspected nothing behind the tag.

## What changed

`-tags` is forwarded through `GOFLAGS`, which the `go` command that `go/packages` shells out to does read. That is the one channel that reaches the loader without replacing the driver, and replacing the driver would cost `-fix`, `-diff`, `-json`, `-c`, the `-flags` inventory that `go vet -vettool` reads, and the `.cfg` dispatch that makes qtlint usable as a vet tool at all.

The spellings were measured against the `go` command rather than assumed, and match it:

| Spelling | Behavior |
| --- | --- |
| `-tags a,b` | both tags satisfied |
| `-tags 'a b'` | both tags satisfied (the spelling go kept for Go 1.12 and earlier) |
| `-tags a -tags b` | last wins — a repeat replaces, it does not accumulate |
| `-tags=a` / `--tags=a` | same as the separate-argument form |

Precedence matches too: an explicit `-tags` beats an inherited `GOFLAGS`, and a command line that says nothing about tags leaves `GOFLAGS` exactly as it found it.

The driver's `-tags ... no effect (deprecated)` usage line is corrected on its way out, since it now describes the opposite of what the flag does. Other shims keep their wording.

New package `internal/tagsflag` holds the flag scan, the go-compatible value split, and the usage correction. `cmd/qtlint/main.go` gains six lines.

### Known limitation

A custom `GOPACKAGESDRIVER` does not run the `go` command and so will not see the tags. Documented in the README.

## Evidence

**The end-to-end test fails against the code before this change.** It builds the command and runs it against a fixture module in `cmd/qtlint/testdata/tagsmod` carrying both shapes of build constraint: a package that still loads while its constrained test file is dropped, and a package that vanishes from a recursive pattern entirely.

Against unfixed `cmd/qtlint/main.go` (`go build ./...` exit 0, so it fails for the intended reason):

```
--- FAIL: TestTagsReachesTheLoader/space_separated_value
    got:  ["plain/plain_test.go"]
    want: ["hidden/hidden_test.go" "plain/plain_test.go" "quiet/quiet_test.go"]
--- FAIL: TestRecursivePatternDoesNotPassSilently
    reported nothing behind the tag
    exit code = 0 with a violation behind the tag
```

Two rows stay green against the unfixed code, on purpose. `no tag leaves constrained files out of the build` and `no flag keeps the tags already in GOFLAGS` are the acceptance controls: without them, every other row is satisfied by an implementation that simply satisfies every build constraint, or that clobbers the user's `GOFLAGS`.

`TestMatchesVetTool` checks the standalone command against `go vet -tags qtprobe -vettool=<bin> ./...` on the same input. Identical diagnostic sets. (Exit codes differ — 3 standalone, 1 under `go vet` — which is pre-existing driver behavior, not introduced here.)

### Mutants

Six cheaper-wrong implementations, each of which compiles (`go build ./...` and `go vet ./...` exit 0 under every one), each red for its intended reason, each green on revert:

| Mutant | Reddens |
| --- | --- |
| handle only the `-tags=value` spelling | the separate-argument rows, and `TestRecursivePatternDoesNotPassSilently` |
| always split the value on commas | only the space-separated multi-value rows |
| overwrite `GOFLAGS` instead of appending to it | only `an inherited GOFLAGS is kept and overridden` |
| ignore `Forward`'s `ok` and always set `GOFLAGS` | only `no flag keeps the tags already in GOFLAGS` — the acceptance control |
| take the first `-tags` instead of the last | only the `repeated flag takes the last value` rows |
| match the deprecation mark without the flag-name prefix | only `another deprecated shim is untouched` |

## Gates

Each read from an unpiped invocation:

| Gate | Exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go test -race ./... -count=1` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `go mod tidy` then `git diff --exit-code go.mod go.sum` | 0 |

No new dependencies; `go.mod` and `go.sum` are untouched. Coverage 86.1% → 86.3%; `internal/tagsflag` is at 100%.

## Suggested release

**Minor — v1.9.0.** A flag that never worked now works, which is new behavior for existing command lines rather than a bug fix confined to the analyzer's output. Anyone already passing `-tags` in a script will start seeing files that were silently skipped, and some of them will report violations, so a run that exited 0 can now exit 3. That is the intended fix, but it is not a change a patch bump should hide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for forwarding `-tags` build constraints during analysis.
  * Supports comma-separated, space-separated, repeated, and inherited tag settings.
  * Improved help text to accurately describe build-tag behavior.
  * Reports failures when applying relevant environment settings.

* **Documentation**
  * Added examples and guidance for build constraints, package discovery, `go vet` compatibility, `GOFLAGS`, and driver limitations.

* **Tests**
  * Added comprehensive end-to-end coverage for tagged packages, recursive loading, explicit package checks, and help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->