### PR TITLE
feat: cover several modules in one invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ qtlint -fix -require-testing-run ./...
 # Include packages and files behind a build constraint
 qtlint -tags integration ./...
 qtlint -tags integration,e2e ./...
+
+# Cover every module in a repository, not just the one you are standing in
+qtlint -multi-module ./...
+qtlint -multi-module -tags integration ./...
 ```
 
 ### With golangci-lint
@@ -131,6 +135,8 @@ Then run with auto-fix:
 golangci-lint run --fix
 ```
 
+Note that multi-module repositories are a `golangci-lint` concern in this mode rather than a qtlint one: `golangci-lint` runs inside a single module and has no equivalent of `-multi-module` ([golangci-lint#828](https://github.com/golangci/golangci-lint/issues/828) is open at the time of writing), so it is invoked once per module — by hand, or with `automatic-module-directories` in the official GitHub Action. Use the standalone command with `-multi-module` if you want one invocation to cover the whole repository.
+
 ### `-tags` flag
 
 Go source behind a build constraint is not part of the default build, so `qtlint ./...` does not see it. Pass `-tags` to name the constraints to satisfy, exactly as you would to `go build`:
@@ -148,6 +154,56 @@ This matters most on a recursive pattern. A package whose files are all excluded
 Note for anyone who reached for `go vet` instead: `go vet -tags integration -vettool=$(which qtlint) ./...` has always worked, because in that mode `go vet` loads the packages itself. It is still supported and reports the same diagnostics; you no longer need it just to get build tags.
 
 One limitation: `-tags` is forwarded through `GOFLAGS` to the `go` command that loads the packages. A custom `GOPACKAGESDRIVER` does not run the `go` command and so will not see it.
+
+### `-multi-module` flag
+
+`qtlint ./...` analyzes exactly one module: the one holding the working directory. Packages in any other module are not reported as missing, they are simply not there, so a repository of several modules can be linted for months while most of it is never inspected.
+
+This is not a qtlint limitation but a `go` one. `go/packages` resolves patterns by running the `go` command, and the `go` command resolves them against the main module, so a pattern naming a different module is an error rather than a wider search:
+
+```console
+$ qtlint ./testkit/...
+pattern ./testkit/...: directory prefix testkit does not contain main module or its selected dependencies
+```
+
+No spelling avoids it — an absolute path reports the same error, and naming the directory without `...` reports that the main module does not contain that package. A Go workspace does not fix it either: with a `go.work` listing every module, `./testkit/...` starts working, but `./...` still matches only the module you are standing in, so you are still the one enumerating modules.
+
+Pass `-multi-module` and one invocation covers them all:
+
+```bash
+qtlint -multi-module ./...              # every module under the current directory
+qtlint -multi-module ./services/...     # every module under services/
+qtlint -multi-module -fix ./...         # fixes apply in each module
+```
+
+The flag finds every `go.mod` at or under the directories you named, then runs the linter once per module with the working directory set to it. Modules are found rather than listed, so a module added to the repository next month is covered without anyone remembering to add it.
+
+Directories the `go` command ignores when expanding `...` are ignored here too: `vendor`, `testdata`, and any directory whose name begins with `.` or `_`. A repository whose top level holds no `go.mod` at all works — every module comes from the downward search.
+
+**Exit codes** are the driver's own, aggregated so that the worst news wins:
+
+| Exit | Meaning |
+| ---- | ------- |
+| `0`  | every module was analyzed and none reported anything |
+| `3`  | some module reported diagnostics |
+| other | some module could not be analyzed — a load or configuration failure |
+
+A module that fails to load outranks one with diagnostics, because its packages were never inspected and calling that a mere finding would describe work that did not happen. A clean module can never bring the invocation back to `0`. As without the flag, `-json` reports diagnostics in the document and still exits `0`.
+
+**Paths in diagnostics are absolute**, which is what they already were without the flag. Relative paths would be the ambiguous choice here rather than the friendly one: each module is analyzed from its own working directory, so `sub/thing_test.go` would mean a different file depending on which module produced it. `golangci-lint` reached the same conclusion from the other direction — it reports relative paths and added an absolute-path mode ([`output.path-mode: abs`](https://golangci-lint.run/docs/configuration/file/)) precisely because users running it across several projects could not tell which project a finding came from.
+
+**`-tags` composes with it**, and both are worth running:
+
+```bash
+qtlint -multi-module ./...
+qtlint -multi-module -tags integration ./...
+```
+
+Two invocations, not one, and deliberately so. A build tag only ever *adds* files to a build, so satisfying `integration` pulls in the files behind `//go:build integration` and drops the ones behind `//go:build !integration`. Neither run is a superset of the other, and qtlint does not guess which sets of tags your repository means — an unsatisfied constraint is indistinguishable from a nonexistent one, so a tool inventing tag combinations would analyze builds you never ship. Naming the contours is yours; naming the modules is not.
+
+`-json` output is a single document however many modules ran, so anything parsing it does not need to know. Everything else the driver does is unchanged: `-fix`, `-diff`, `-c`, `-only-stable-fixes`, the opt-in rules, and the `-flags` inventory that `go vet -vettool` reads.
+
+Two limitations. The mode needs directory patterns — `./...`, `./x/...`, or a path beginning with `./`, `../` or `/` — and refuses import paths and words like `all`, because those name packages through the module graph and carry no directory to search. And `go vet -vettool=qtlint` does its own package loading, so it still reaches one module; run qtlint directly for the rest.
 
 ### `-only-stable-fixes` flag
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ qtlint -multi-module ./...
 qtlint -multi-module -tags integration ./...
 ```
 
-Two invocations, not one, and deliberately so. A build tag only ever *adds* files to a build, so satisfying `integration` pulls in the files behind `//go:build integration` and drops the ones behind `//go:build !integration`. Neither run is a superset of the other, and qtlint does not guess which sets of tags your repository means — an unsatisfied constraint is indistinguishable from a nonexistent one, so a tool inventing tag combinations would analyze builds you never ship. Naming the contours is yours; naming the modules is not.
+Two invocations, not one, and deliberately so. A tag does not widen a build, it selects a different one: satisfying `integration` pulls in the files behind `//go:build integration` and at the same time drops those behind `//go:build !integration`. So neither run is a superset of the other, and running only the tagged one leaves the `!integration` files unlinted. qtlint does not guess which sets of tags your repository means — an unsatisfied constraint is indistinguishable from a nonexistent one, so a tool inventing tag combinations would analyze builds you never ship. Naming the contours is yours; naming the modules is not.
 
 `-json` output is a single document however many modules ran, so anything parsing it does not need to know. Everything else the driver does is unchanged: `-fix`, `-diff`, `-c`, `-only-stable-fixes`, the opt-in rules, and the `-flags` inventory that `go vet -vettool` reads.
 

--- a/cmd/qtlint/main.go
+++ b/cmd/qtlint/main.go
@@ -27,8 +27,35 @@ import (
 	"golang.org/x/tools/go/analysis/singlechecker"
 
 	"github.com/go-extras/qtlint"
+	"github.com/go-extras/qtlint/internal/modules"
 	"github.com/go-extras/qtlint/internal/tagsflag"
 )
+
+// executable returns the path to re-run for each module.
+//
+// The reliable spelling is os.Executable. Argument zero is whatever the caller
+// typed, and it need not resolve from another working directory, which is
+// exactly where each module run puts it. Falling back to it is still better
+// than refusing, because a relative argument zero only fails once the run
+// starts, and says so plainly when it does.
+func executable() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return os.Args[0]
+	}
+
+	return exe
+}
+
+// workingDir returns the directory package patterns are written relative to.
+func workingDir() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+
+	return wd
+}
 
 // Build information. Populated at build-time via ldflags.
 var (
@@ -48,6 +75,27 @@ func main() {
 
 	// Add custom version flag.
 	flag.Bool("version", false, "print version and exit")
+
+	// Registered so that -h describes it and the driver's own parse accepts
+	// it; the mode itself is decided below, before the driver ever parses.
+	flag.Bool(modules.FlagName, false, modules.Usage)
+
+	// A pattern naming a module other than the one holding the working
+	// directory is an error the go command reports, whatever the spelling, so
+	// covering several modules means running once per module with the working
+	// directory moved. That has to happen before the driver starts, because
+	// the driver parses the global flag set and exits without returning. See
+	// package modules.
+	if code, handled, err := modules.Dispatch(
+		executable(), workingDir(), os.Args[1:], os.Stdout, os.Stderr,
+	); handled {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "qtlint: %v\n", err)
+			os.Exit(1)
+		}
+
+		os.Exit(code)
+	}
 
 	// The analysis driver accepts -tags but does nothing with it, and it never
 	// hands out the package-loading configuration where build tags would

--- a/cmd/qtlint/multimodule_test.go
+++ b/cmd/qtlint/multimodule_test.go
@@ -20,6 +20,10 @@ import (
 // multimodDir is the multi-module fixture, relative to this package.
 const multimodDir = "testdata/multimod"
 
+// brokenmodDir is the fixture for exit-code precedence: an outer module with a
+// violation, and a module nested inside it that does not type-check.
+const brokenmodDir = "testdata/brokenmod"
+
 // The violations planted in the fixture, as fixture-relative paths.
 //
 // Each names the contour it belongs to. Two of them are the point of the
@@ -193,6 +197,42 @@ func TestFindingsInAnyModuleOutrankACleanOne(t *testing.T) {
 	}
 	if got.code != 3 {
 		t.Errorf("exit code = %d, want the driver's own 3 for diagnostics; output:\n%s", got.code, got.output)
+	}
+}
+
+// TestALoadFailureOutranksDiagnostics pins the other half of the exit code.
+//
+// A module the driver could not analyze is worse news than a module with
+// diagnostics: its packages were never inspected, and reporting that as a
+// finding would describe work that did not happen. The two controls are what
+// make the third line mean anything — without them a rule that always returned
+// 1, or one that returned whatever the last module gave, would satisfy it.
+func TestALoadFailureOutranksDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	dir := fixturePath(t, brokenmodDir)
+
+	good := runCommand(t, dir, nil, qtlintBin, "-multi-module", "./good/...")
+	if good.code != 3 {
+		t.Fatalf("the module with a violation exited %d, want 3; output:\n%s", good.code, good.output)
+	}
+
+	broken := runCommand(t, dir, nil, qtlintBin, "-multi-module", "./broken/...")
+	if broken.code != 1 {
+		t.Fatalf("the module that cannot load exited %d, want 1; output:\n%s", broken.code, broken.output)
+	}
+
+	both := runCommand(t, dir, nil, qtlintBin, "-multi-module", "./...")
+	if both.code != 1 {
+		t.Errorf("together they exited %d, want 1: a module that was never analyzed "+
+			"must not be reported as a mere finding; output:\n%s", both.code, both.output)
+	}
+
+	// The failing module must not have ended the run either. The caller asked
+	// about every module, and stopping early would hide the findings a later
+	// one was about to report.
+	if len(both.files) == 0 {
+		t.Errorf("no diagnostics reported, so the failing module stopped the run; output:\n%s", both.output)
 	}
 }
 

--- a/cmd/qtlint/multimodule_test.go
+++ b/cmd/qtlint/multimodule_test.go
@@ -1,0 +1,385 @@
+// Multi-module tests for the qtlint command.
+//
+// Like the -tags tests next to them, these drive the built binary: the wiring
+// under test decides which working directory the analysis driver loads packages
+// from, and nothing short of running the command can see that. The fixture
+// module in testdata/multimod holds three modules, two of them nested inside
+// the first, so that a single invocation has something to cover that no
+// package pattern can reach.
+package main_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// multimodDir is the multi-module fixture, relative to this package.
+const multimodDir = "testdata/multimod"
+
+// The violations planted in the fixture, as fixture-relative paths.
+//
+// Each names the contour it belongs to. Two of them are the point of the
+// fixture: tagged is in the build only when the integration tag is set, and
+// untagged only when it is not, because a build tag adds files to a build and
+// never removes any. No single run reports both.
+const (
+	root     = "root/root_test.go"           // no constraint, every run
+	untagged = "contour/plain_test.go"       // //go:build !integration
+	tagged   = "contour/integration_test.go" // //go:build integration
+	nested   = "nested/sub/sub_test.go"      // second module, no constraint
+	quiet    = "quiet/hush/hush_test.go"     // third module, //go:build integration
+)
+
+// runMultimod runs the command in the multi-module fixture.
+func runMultimod(t *testing.T, args ...string) result {
+	t.Helper()
+
+	return runCommand(t, fixturePath(t, multimodDir), nil, qtlintBin, args...)
+}
+
+// TestMultiModuleReachesEveryModule is the test that separates an invocation
+// covering one module from one covering all of them. Every row states the files
+// the go command puts in the build for that spelling, across every module the
+// pattern reaches.
+func TestMultiModuleReachesEveryModule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+		code int
+	}{{
+		// The acceptance control. Without the flag the command still sees
+		// one module, so every row below is a statement about the flag
+		// rather than about the fixture.
+		name: "without the flag only the module holding the pattern is seen",
+		args: []string{"./..."},
+		want: []string{untagged, root},
+		code: 3,
+	}, {
+		name: "the flag reaches the modules nested inside that one",
+		args: []string{"-multi-module", "./..."},
+		want: []string{untagged, root, nested},
+		code: 3,
+	}, {
+		name: "build tags reach every module the flag found",
+		args: []string{"-multi-module", "-tags", "integration", "./..."},
+		want: []string{tagged, root, nested, quiet},
+		code: 3,
+	}, {
+		// A pattern naming one nested module covers that module alone.
+		// The outer module's violations must not come back with it.
+		name: "a pattern naming a nested module covers only that module",
+		args: []string{"-multi-module", "./nested/..."},
+		want: []string{nested},
+		code: 3,
+	}, {
+		// ...and a pattern naming a subtree of the outer module must not
+		// widen to the whole of it.
+		name: "a pattern naming a subtree keeps that subtree",
+		args: []string{"-multi-module", "./root/..."},
+		want: []string{root},
+		code: 3,
+	}, {
+		name: "a clean module reports nothing and exits 0",
+		args: []string{"-multi-module", "./quiet/..."},
+		want: nil,
+		code: 0,
+	}, {
+		// Several patterns are a union, and a module named twice is run
+		// once rather than reported twice.
+		name: "several patterns are covered together",
+		args: []string{"-multi-module", "./nested/...", "./root/..."},
+		want: []string{root, nested},
+		code: 3,
+	}, {
+		name: "the flag can be turned off the way the flag package spells it",
+		args: []string{"-multi-module=false", "./..."},
+		want: []string{untagged, root},
+		code: 3,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := runMultimod(t, tc.args...)
+
+			want := slices.Clone(tc.want)
+			slices.Sort(want)
+
+			if !slices.Equal(got.files, want) {
+				t.Errorf("reported files\ngot:  %q\nwant: %q\noutput:\n%s", got.files, want, got.output)
+			}
+			if got.code != tc.code {
+				t.Errorf("exit code = %d, want %d; output:\n%s", got.code, tc.code, got.output)
+			}
+		})
+	}
+}
+
+// TestNeitherContourAloneReportsEverything pins why a tagged run cannot stand
+// in for a plain one, whatever the module coverage is.
+//
+// A build tag only ever adds files to a build. Satisfying "integration" brings
+// the tagged file in and takes the "!integration" file out, so each run has a
+// violation the other cannot see, and only the two together report all five.
+// Without this, a change that quietly ran everything with the tag set would
+// still satisfy every other test here.
+func TestNeitherContourAloneReportsEverything(t *testing.T) {
+	t.Parallel()
+
+	plain := runMultimod(t, "-multi-module", "./...")
+	integration := runMultimod(t, "-multi-module", "-tags", "integration", "./...")
+
+	if slices.Contains(plain.files, tagged) {
+		t.Errorf("the plain run reported %s, which is behind the tag:\n%s", tagged, plain.output)
+	}
+	if slices.Contains(integration.files, untagged) {
+		t.Errorf("the tagged run reported %s, which the tag excludes:\n%s", untagged, integration.output)
+	}
+
+	union := slices.Concat(plain.files, integration.files)
+	slices.Sort(union)
+	union = slices.Compact(union)
+
+	want := []string{tagged, untagged, nested, quiet, root}
+	slices.Sort(want)
+
+	if !slices.Equal(union, want) {
+		t.Errorf("the two runs together\ngot:  %q\nwant: %q", union, want)
+	}
+}
+
+// TestTaggedOnlyModuleDoesNotPassSilently pins the failure shape this tool has
+// hidden twice.
+//
+// The third fixture module's only violation sits behind a build constraint. A
+// package excluded by a constraint is not an error, it is simply absent, so a
+// run that never reached the module and a run that reached it and found nothing
+// produce the same silence and the same exit code. This asks for the tag and
+// requires both a report and a non-zero exit, which is the only pair the two
+// cases do not share.
+func TestTaggedOnlyModuleDoesNotPassSilently(t *testing.T) {
+	t.Parallel()
+
+	got := runMultimod(t, "-multi-module", "-tags", "integration", "./quiet/...")
+
+	if !slices.Contains(got.files, quiet) {
+		t.Errorf("reported nothing behind the tag; output:\n%s", got.output)
+	}
+	if got.code == 0 {
+		t.Errorf("exit code = 0 with a violation behind the tag; output:\n%s", got.output)
+	}
+}
+
+// TestFindingsInAnyModuleOutrankACleanOne pins the exit code, which is what a
+// CI job reads. A module with no findings must not carry the invocation to 0
+// when another module has them, whichever order they run in.
+func TestFindingsInAnyModuleOutrankACleanOne(t *testing.T) {
+	t.Parallel()
+
+	// The quiet module is clean without the tag, and sorts after the two
+	// modules that are not, so it is the last word on the exit code.
+	got := runMultimod(t, "-multi-module", "./...")
+
+	if got.code == 0 {
+		t.Errorf("exit code = 0 with findings in other modules; output:\n%s", got.output)
+	}
+	if got.code != 3 {
+		t.Errorf("exit code = %d, want the driver's own 3 for diagnostics; output:\n%s", got.code, got.output)
+	}
+}
+
+// TestJSONIsOneDocument checks that -json survives the change.
+//
+// The driver prints one JSON object per run, and a caller parsing qtlint's
+// output must not have to know that several processes produced it. Two objects
+// written one after another are not a JSON document at all, so this parses the
+// output strictly and requires packages from more than one module inside it.
+func TestJSONIsOneDocument(t *testing.T) {
+	t.Parallel()
+
+	got := runMultimod(t, "-multi-module", "-json", "./...")
+
+	var tree map[string]map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got.stdout), &tree); err != nil {
+		t.Fatalf("output is not one JSON document: %v\ngot:\n%s", err, got.stdout)
+	}
+
+	var modules []string
+	for pkg := range tree {
+		module, _, _ := strings.Cut(pkg, " ")
+		modules = append(modules, module)
+	}
+
+	for _, want := range []string{"qtlint.test/multimod/contour", "qtlint.test/nested/sub"} {
+		if !slices.Contains(modules, want) {
+			t.Errorf("package %q missing from the combined document; got %q", want, modules)
+		}
+	}
+
+	// The driver exits 0 in -json mode even with diagnostics, reporting
+	// them in the document instead. That is preserved rather than corrected.
+	if got.code != 0 {
+		t.Errorf("exit code = %d, want 0 as the driver gives in -json mode; output:\n%s", got.code, got.output)
+	}
+}
+
+// TestFixAppliesInEveryModule checks that -fix survives the change, which is
+// one of the things replacing the analysis driver would have cost.
+func TestFixAppliesInEveryModule(t *testing.T) {
+	t.Parallel()
+
+	// -fix rewrites files, so it runs against a copy rather than against
+	// the fixture every other test reads.
+	//
+	// The symlinks are resolved because the driver reports the resolved path
+	// of every file. On macOS the temporary directory is reached through
+	// /var, a symlink to /private/var, so an unresolved directory would make
+	// every diagnostic look like it came from outside the tree and this test
+	// would pass while reading nothing.
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
+
+	copyTree(t, fixturePath(t, multimodDir), dir)
+
+	got := runCommand(t, dir, nil, qtlintBin, "-multi-module", "./...")
+	if len(got.files) == 0 {
+		t.Fatalf("nothing to fix, so this proves nothing; output:\n%s", got.output)
+	}
+
+	if fixed := runCommand(t, dir, nil, qtlintBin, "-multi-module", "-fix", "./..."); fixed.code != 0 {
+		t.Fatalf("fix run exited %d; output:\n%s", fixed.code, fixed.output)
+	}
+
+	after := runCommand(t, dir, nil, qtlintBin, "-multi-module", "./...")
+	if len(after.files) != 0 {
+		t.Errorf("still reported after -fix: %q\noutput:\n%s", after.files, after.output)
+	}
+
+	// The nested module is the one no pattern can reach, so it is the one
+	// worth reading back.
+	body, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(nested)))
+	if err != nil {
+		t.Fatalf("read %s: %v", nested, err)
+	}
+	if !strings.Contains(string(body), "qt.IsNotNil") {
+		t.Errorf("%s was not rewritten:\n%s", nested, body)
+	}
+}
+
+// TestFlagInventoryIsPrintedOnce checks the mode "go vet -vettool" depends on.
+//
+// -flags is how go vet learns which flags the tool accepts, and it advertises
+// every flag on the global set, this one included. So go vet can be asked for
+// -multi-module, and the flag must not turn one inventory into one per module.
+func TestFlagInventoryIsPrintedOnce(t *testing.T) {
+	t.Parallel()
+
+	// The pattern is recursive on purpose. Without it the plan holds one
+	// module, one inventory is printed either way, and this would pass just
+	// as happily if -flags were not exempt from the expansion at all.
+	got := runMultimod(t, "-multi-module", "-flags", "./...")
+
+	var flags []struct {
+		Name string
+		Bool bool
+	}
+	if err := json.Unmarshal([]byte(got.stdout), &flags); err != nil {
+		t.Fatalf("-flags did not print one JSON document: %v\ngot:\n%s", err, got.stdout)
+	}
+
+	var names []string
+	for _, f := range flags {
+		names = append(names, f.Name)
+	}
+
+	if !slices.Contains(names, "multi-module") {
+		t.Errorf("-flags does not advertise the flag; got %q", names)
+	}
+}
+
+// TestVetToolStillWorks checks that the flag has not disturbed the .cfg
+// dispatch, the mode that makes qtlint usable as a vet tool at all. The vet
+// command does its own package loading, so it reaches one module, and that is
+// the answer it should still give.
+func TestVetToolStillWorks(t *testing.T) {
+	t.Parallel()
+
+	dir := fixturePath(t, multimodDir)
+
+	want := []string{untagged, root}
+	slices.Sort(want)
+
+	vet := runCommand(t, dir, nil, "go", "vet", "-vettool="+qtlintBin, "./...")
+	if !slices.Equal(vet.files, want) {
+		t.Errorf("go vet -vettool reported\ngot:  %q\nwant: %q\noutput:\n%s", vet.files, want, vet.output)
+	}
+
+	// go vet learns the tool's flags from -flags, which advertises this one,
+	// so it accepts -multi-module and forwards it to the .cfg invocation. That
+	// invocation has already been told exactly which package to analyze, and
+	// must pass straight through rather than plan an expansion of its own.
+	// Without the .cfg exemption this run fails outright.
+	flagged := runCommand(t, dir, nil, "go", "vet", "-multi-module", "-vettool="+qtlintBin, "./...")
+	if !slices.Equal(flagged.files, want) {
+		t.Errorf("go vet -multi-module -vettool reported\ngot:  %q\nwant: %q\noutput:\n%s",
+			flagged.files, want, flagged.output)
+	}
+}
+
+// TestRefusesPatternsItCannotResolve pins the refusal.
+//
+// Multi-module mode turns a pattern into directories to search for go.mod
+// files, and an import path or a reserved word such as "all" carries no
+// directory. Analyzing whatever subset happened to resolve and exiting 0 is the
+// shape of a run that looks clean because it inspected nothing, so such a
+// pattern is refused instead.
+func TestRefusesPatternsItCannotResolve(t *testing.T) {
+	t.Parallel()
+
+	for _, pattern := range []string{"all", "qtlint.test/multimod/..."} {
+		t.Run(pattern, func(t *testing.T) {
+			t.Parallel()
+
+			got := runMultimod(t, "-multi-module", pattern)
+
+			if got.code == 0 {
+				t.Errorf("exit code = 0 for %q; output:\n%s", pattern, got.output)
+			}
+			if !strings.Contains(got.output, "directory patterns") {
+				t.Errorf("refusal does not say what is wrong; output:\n%s", got.output)
+			}
+		})
+	}
+}
+
+// TestHelpDescribesTheFlag checks that -h says the mode exists. A capability
+// nobody can discover is one nobody uses.
+func TestHelpDescribesTheFlag(t *testing.T) {
+	t.Parallel()
+
+	got := runMultimod(t, "-h")
+
+	if !strings.Contains(got.output, "-multi-module") {
+		t.Errorf("help does not mention the flag:\n%s", got.output)
+	}
+}
+
+// copyTree copies the fixture into dir so that a -fix run has something of its
+// own to rewrite.
+func copyTree(t *testing.T, from, to string) {
+	t.Helper()
+
+	if err := os.CopyFS(to, os.DirFS(from)); err != nil {
+		t.Fatalf("copy %s: %v", from, err)
+	}
+}

--- a/cmd/qtlint/tags_test.go
+++ b/cmd/qtlint/tags_test.go
@@ -170,7 +170,7 @@ func TestMatchesVetTool(t *testing.T) {
 	t.Parallel()
 
 	standalone := runQtlint(t, nil, "-tags", "qtprobe", "./...")
-	vet := runCommand(t, nil, "go", "vet", "-tags", "qtprobe", "-vettool="+qtlintBin, "./...")
+	vet := runCommand(t, fixturePath(t, fixtureDir), nil, "go", "vet", "-tags", "qtprobe", "-vettool="+qtlintBin, "./...")
 
 	if !slices.Equal(standalone.files, vet.files) {
 		t.Errorf("standalone and vettool disagree\nstandalone: %q\nvettool:    %q", standalone.files, vet.files)
@@ -206,20 +206,23 @@ type result struct {
 	files []string
 	// code is the process exit code.
 	code int
-	// output is stdout and stderr, for failure messages.
+	// output is standard output followed by standard error, for
+	// failure messages.
 	output string
+	// stdout is standard output alone. The driver prints diagnostics to
+	// standard error and its JSON documents to standard output, so a test
+	// about -json or -flags has to read this rather than the mixture.
+	stdout string
 }
 
 func runQtlint(t *testing.T, env []string, args ...string) result {
 	t.Helper()
 
-	return runCommand(t, env, qtlintBin, args...)
+	return runCommand(t, fixturePath(t, fixtureDir), env, qtlintBin, args...)
 }
 
-func runCommand(t *testing.T, env []string, name string, args ...string) result {
+func runCommand(t *testing.T, dir string, env []string, name string, args ...string) result {
 	t.Helper()
-
-	dir := fixturePath(t)
 
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
@@ -230,22 +233,33 @@ func runCommand(t *testing.T, env []string, name string, args ...string) result 
 	cmd.Env = append(os.Environ(), "GOFLAGS=", "GOWORK=off")
 	cmd.Env = append(cmd.Env, env...)
 
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
+	// The two streams are captured separately rather than into one buffer.
+	// os/exec serializes writes only when Stdout and Stderr are the same
+	// comparable value; anything else, a wrapper included, gets a goroutine
+	// each and they would race on the shared buffer.
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
 	code := 0
 	err := cmd.Run()
+
+	output := stdout.String() + stderr.String()
 
 	var exitErr *exec.ExitError
 	switch {
 	case errors.As(err, &exitErr):
 		code = exitErr.ExitCode()
 	case err != nil:
-		t.Fatalf("run %s %q: %v\n%s", name, args, err, out.String())
+		t.Fatalf("run %s %q: %v\n%s", name, args, err, output)
 	}
 
-	return result{files: diagnosedFiles(dir, out.String()), code: code, output: out.String()}
+	return result{
+		files:  diagnosedFiles(dir, output),
+		code:   code,
+		output: output,
+		stdout: stdout.String(),
+	}
 }
 
 // diagnosedFiles extracts the fixture-relative file of every diagnostic in
@@ -280,13 +294,13 @@ func diagnosedFiles(dir, output string) []string {
 	return slices.Compact(files)
 }
 
-func fixturePath(t *testing.T) string {
+func fixturePath(t *testing.T, dir string) string {
 	t.Helper()
 
-	dir, err := filepath.Abs(fixtureDir)
+	abs, err := filepath.Abs(dir)
 	if err != nil {
-		t.Fatalf("locate %s: %v", fixtureDir, err)
+		t.Fatalf("locate %s: %v", dir, err)
 	}
 
-	return dir
+	return abs
 }

--- a/cmd/qtlint/testdata/brokenmod/broken/go.mod
+++ b/cmd/qtlint/testdata/brokenmod/broken/go.mod
@@ -1,0 +1,5 @@
+// A nested module that does not type-check, so the analyzer is skipped for it
+// and the driver reports a load failure rather than diagnostics.
+module qtlint.test/broken
+
+go 1.21

--- a/cmd/qtlint/testdata/brokenmod/broken/pkg/pkg.go
+++ b/cmd/qtlint/testdata/brokenmod/broken/pkg/pkg.go
@@ -1,0 +1,5 @@
+package pkg
+
+// Broken refers to something that does not exist, so this package cannot be
+// analyzed. Being unanalyzable is the whole point of the fixture.
+func Broken() int { return undefinedThing }

--- a/cmd/qtlint/testdata/brokenmod/go.mod
+++ b/cmd/qtlint/testdata/brokenmod/go.mod
@@ -1,0 +1,10 @@
+// The outer module of the fixture that pins exit-code precedence. It holds a
+// violation, so on its own it would exit 3; the module nested inside it cannot
+// be analyzed at all, and that has to be the answer instead.
+module qtlint.test/brokenmod
+
+go 1.21
+
+require github.com/frankban/quicktest v0.0.0
+
+replace github.com/frankban/quicktest => ./quicktest

--- a/cmd/qtlint/testdata/brokenmod/good/good.go
+++ b/cmd/qtlint/testdata/brokenmod/good/good.go
@@ -1,0 +1,4 @@
+package good
+
+// Name keeps this package non-empty.
+const Name = "good"

--- a/cmd/qtlint/testdata/brokenmod/good/good_test.go
+++ b/cmd/qtlint/testdata/brokenmod/good/good_test.go
@@ -1,0 +1,14 @@
+package good
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestGood is a plain violation in a module that loads correctly.
+func TestGood(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/brokenmod/quicktest/go.mod
+++ b/cmd/qtlint/testdata/brokenmod/quicktest/go.mod
@@ -1,0 +1,3 @@
+module github.com/frankban/quicktest
+
+go 1.21

--- a/cmd/qtlint/testdata/brokenmod/quicktest/quicktest.go
+++ b/cmd/qtlint/testdata/brokenmod/quicktest/quicktest.go
@@ -1,0 +1,39 @@
+// Package quicktest is a stub for the -tags end-to-end fixture. It is not the
+// real quicktest package and declares only what the fixture files below it
+// need to type-check.
+package quicktest
+
+import "testing"
+
+// C is a quicktest checker.
+type C struct {
+	TB testing.TB
+}
+
+// New returns a new checker instance.
+func New(t testing.TB) *C {
+	return &C{TB: t}
+}
+
+// Assert runs the given check and stops execution in case of failure.
+func (c *C) Assert(got any, checker Checker, args ...any) bool {
+	return true
+}
+
+// Checker is the interface implemented by quicktest checkers.
+type Checker interface {
+	Check(got any, args []any) error
+}
+
+type checkerFunc struct{}
+
+func (checkerFunc) Check(got any, args []any) error { return nil }
+
+// IsNil checks that a value is nil.
+var IsNil Checker = checkerFunc{}
+
+// IsNotNil checks that a value is not nil.
+var IsNotNil Checker = checkerFunc{}
+
+// Not negates a checker.
+func Not(c Checker) Checker { return c }

--- a/cmd/qtlint/testdata/brokenmod/zlast/go.mod
+++ b/cmd/qtlint/testdata/brokenmod/zlast/go.mod
@@ -1,0 +1,11 @@
+// A third module, named so that it sorts after the module that cannot load.
+// That ordering is the point: the precedence rule is only observable when a
+// module with diagnostics runs after a module that failed, so a rule that
+// simply let the newest result win would still be caught.
+module qtlint.test/zlast
+
+go 1.21
+
+require github.com/frankban/quicktest v0.0.0
+
+replace github.com/frankban/quicktest => ../quicktest

--- a/cmd/qtlint/testdata/brokenmod/zlast/pkg/pkg.go
+++ b/cmd/qtlint/testdata/brokenmod/zlast/pkg/pkg.go
@@ -1,0 +1,4 @@
+package pkg
+
+// Name keeps this package non-empty.
+const Name = "zlast"

--- a/cmd/qtlint/testdata/brokenmod/zlast/pkg/pkg_test.go
+++ b/cmd/qtlint/testdata/brokenmod/zlast/pkg/pkg_test.go
@@ -1,0 +1,14 @@
+package pkg
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestZlast is a violation in the module that runs last.
+func TestZlast(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/multimod/contour/contour.go
+++ b/cmd/qtlint/testdata/multimod/contour/contour.go
@@ -1,0 +1,5 @@
+package contour
+
+// Name keeps this package loadable whichever of the two constrained test files
+// is in the build.
+const Name = "contour"

--- a/cmd/qtlint/testdata/multimod/contour/integration_test.go
+++ b/cmd/qtlint/testdata/multimod/contour/integration_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package contour
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestOnlyTagged is reached only when the integration tag is set.
+func TestOnlyTagged(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/multimod/contour/plain_test.go
+++ b/cmd/qtlint/testdata/multimod/contour/plain_test.go
@@ -1,0 +1,18 @@
+//go:build !integration
+
+package contour
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestOnlyUntagged is dropped from the build as soon as the integration tag is
+// set. It is why a tagged run cannot stand in for a plain one: a build tag only
+// ever adds files to a build, so satisfying it removes this file from view.
+func TestOnlyUntagged(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/multimod/go.mod
+++ b/cmd/qtlint/testdata/multimod/go.mod
@@ -1,0 +1,11 @@
+// This module is the outer module of the multi-module end-to-end fixture. It
+// lives under testdata so the go tool never walks into it from the qtlint
+// module, and it replaces quicktest with a local stub so it resolves with no
+// network and no go.sum.
+module qtlint.test/multimod
+
+go 1.21
+
+require github.com/frankban/quicktest v0.0.0
+
+replace github.com/frankban/quicktest => ./quicktest

--- a/cmd/qtlint/testdata/multimod/nested/go.mod
+++ b/cmd/qtlint/testdata/multimod/nested/go.mod
@@ -1,0 +1,10 @@
+// A module nested inside the outer module. The go command refuses to reach it
+// from there by any spelling of a package pattern, which is what the
+// multi-module mode exists to solve.
+module qtlint.test/nested
+
+go 1.21
+
+require github.com/frankban/quicktest v0.0.0
+
+replace github.com/frankban/quicktest => ../quicktest

--- a/cmd/qtlint/testdata/multimod/nested/sub/sub.go
+++ b/cmd/qtlint/testdata/multimod/nested/sub/sub.go
@@ -1,0 +1,4 @@
+package sub
+
+// Name keeps this package non-empty without a build constraint.
+const Name = "sub"

--- a/cmd/qtlint/testdata/multimod/nested/sub/sub_test.go
+++ b/cmd/qtlint/testdata/multimod/nested/sub/sub_test.go
@@ -1,0 +1,14 @@
+package sub
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestSub carries the nested module's unconstrained violation.
+func TestSub(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/multimod/quicktest/go.mod
+++ b/cmd/qtlint/testdata/multimod/quicktest/go.mod
@@ -1,0 +1,3 @@
+module github.com/frankban/quicktest
+
+go 1.21

--- a/cmd/qtlint/testdata/multimod/quicktest/quicktest.go
+++ b/cmd/qtlint/testdata/multimod/quicktest/quicktest.go
@@ -1,0 +1,39 @@
+// Package quicktest is a stub for the -tags end-to-end fixture. It is not the
+// real quicktest package and declares only what the fixture files below it
+// need to type-check.
+package quicktest
+
+import "testing"
+
+// C is a quicktest checker.
+type C struct {
+	TB testing.TB
+}
+
+// New returns a new checker instance.
+func New(t testing.TB) *C {
+	return &C{TB: t}
+}
+
+// Assert runs the given check and stops execution in case of failure.
+func (c *C) Assert(got any, checker Checker, args ...any) bool {
+	return true
+}
+
+// Checker is the interface implemented by quicktest checkers.
+type Checker interface {
+	Check(got any, args []any) error
+}
+
+type checkerFunc struct{}
+
+func (checkerFunc) Check(got any, args []any) error { return nil }
+
+// IsNil checks that a value is nil.
+var IsNil Checker = checkerFunc{}
+
+// IsNotNil checks that a value is not nil.
+var IsNotNil Checker = checkerFunc{}
+
+// Not negates a checker.
+func Not(c Checker) Checker { return c }

--- a/cmd/qtlint/testdata/multimod/quiet/go.mod
+++ b/cmd/qtlint/testdata/multimod/quiet/go.mod
@@ -1,0 +1,11 @@
+// A second nested module whose only violation sits behind a build constraint.
+// Without the tag it is not an error, it is simply absent, so a run that never
+// reached this module and a run that reached it and found nothing look the
+// same from the outside. That is the shape this fixture exists to tell apart.
+module qtlint.test/quiet
+
+go 1.21
+
+require github.com/frankban/quicktest v0.0.0
+
+replace github.com/frankban/quicktest => ../quicktest

--- a/cmd/qtlint/testdata/multimod/quiet/hush/hush.go
+++ b/cmd/qtlint/testdata/multimod/quiet/hush/hush.go
@@ -1,0 +1,5 @@
+package hush
+
+// Name keeps this package loadable, and clean, when the constrained test file
+// is excluded. So a run without the tag reports nothing here and exits 0.
+const Name = "hush"

--- a/cmd/qtlint/testdata/multimod/quiet/hush/hush_test.go
+++ b/cmd/qtlint/testdata/multimod/quiet/hush/hush_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+package hush
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestHush is the only violation in its module, and it is behind a tag.
+func TestHush(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/testdata/multimod/root/root.go
+++ b/cmd/qtlint/testdata/multimod/root/root.go
@@ -1,0 +1,4 @@
+package root
+
+// Name keeps this package non-empty without a build constraint.
+const Name = "root"

--- a/cmd/qtlint/testdata/multimod/root/root_test.go
+++ b/cmd/qtlint/testdata/multimod/root/root_test.go
@@ -1,0 +1,15 @@
+package root
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestRoot carries the outer module's unconstrained violation, so every run
+// reports it whatever the build tags are.
+func TestRoot(t *testing.T) {
+	c := qt.New(t)
+	var x *int
+	c.Assert(x, qt.Not(qt.IsNil))
+}

--- a/cmd/qtlint/valueflags_test.go
+++ b/cmd/qtlint/valueflags_test.go
@@ -1,0 +1,58 @@
+// Drift guard for the driver flag table in internal/modules.
+//
+// It lives beside the command because that is where the binary is built, and in
+// its own file because it is the one multi-module test that reaches into the
+// package rather than driving the command as a program.
+package main_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-extras/qtlint/internal/modules"
+)
+
+// TestValueFlagsMatchesTheDriver pins the one piece of the driver's flag set
+// this change has to know about.
+//
+// Deciding which arguments are package operands means knowing which flags take
+// their value as a separate argument, and the driver builds its flag set inside
+// singlechecker.Main — after the point where that decision has to be made. So
+// the list is written down, and this reads the built binary's own -h to check
+// it is still right. An x/tools release that adds a value-taking flag turns
+// into a failure here rather than into a command line silently misread.
+func TestValueFlagsMatchesTheDriver(t *testing.T) {
+	t.Parallel()
+
+	got := runMultimod(t, "-h")
+
+	var takesValue []string
+
+	for _, line := range strings.Split(got.output, "\n") {
+		if !strings.HasPrefix(line, "  -") {
+			continue
+		}
+
+		// The flag package writes "  -name" for a boolean and
+		// "  -name type" for anything else, then a tab before any usage
+		// text it puts on the same line.
+		head, _, _ := strings.Cut(strings.TrimPrefix(line, "  -"), "\t")
+		if name, _, ok := strings.Cut(strings.TrimSpace(head), " "); ok {
+			takesValue = append(takesValue, name)
+		}
+	}
+
+	slices.Sort(takesValue)
+
+	if len(takesValue) == 0 {
+		t.Fatalf("read no flags out of -h, so this proves nothing:\n%s", got.output)
+	}
+
+	want := modules.ValueFlags()
+	if !slices.Equal(takesValue, want) {
+		t.Errorf("the driver's value-taking flags have changed\n"+
+			"driver -h: %q\nmodules:   %q\n"+
+			"update valueFlags in internal/modules", takesValue, want)
+	}
+}

--- a/internal/modules/dispatch.go
+++ b/internal/modules/dispatch.go
@@ -1,0 +1,112 @@
+package modules
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// Usage is the description of the flag, shown by -h.
+const Usage = "analyze every module found under the given directory patterns, " +
+	"running the linter once per module"
+
+// IsChild reports whether this process was started by a multi-module parent.
+func IsChild() bool { return os.Getenv(childEnv) != "" }
+
+// Dispatch runs the multi-module expansion when args ask for it, and reports
+// whether it handled the invocation.
+//
+// A false report means this invocation is an ordinary one and the caller should
+// go on to the analysis driver unchanged, which is what keeps single-module
+// behavior exactly as it was: nothing here runs unless the flag is present.
+func Dispatch(exe, wd string, args []string, stdout, stderr io.Writer) (code int, handled bool, err error) {
+	rest, on := Requested(args)
+	if !on {
+		return 0, false, nil
+	}
+
+	// A child re-running for one module must analyze that module rather than
+	// expand again, and Requested having removed the flag from the arguments
+	// it hands the child is what ensures that. Reaching here as a child means
+	// that removal stopped working, so it is reported rather than absorbed:
+	// the failure it leads to is unbounded process creation, and a guard that
+	// silently covers for a broken one leaves nothing to notice.
+	if IsChild() {
+		return 0, true, fmt.Errorf(
+			"-%s reached a child process, which would expand again; "+
+				"this is a bug in qtlint, not in the command line", FlagName)
+	}
+
+	flags, operands := SplitArgs(rest)
+	if !analyzes(flags, operands) {
+		return 0, false, nil
+	}
+
+	runs, err := Plan(wd, operands)
+	if err != nil {
+		return 0, true, err
+	}
+
+	code, err = Execute(runs, Options{
+		Exe:    exe,
+		Flags:  flags,
+		JSON:   hasFlag(flags, "json"),
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+	if err != nil {
+		return 0, true, err
+	}
+
+	return code, true, nil
+}
+
+// analyzes reports whether this command line asks the driver to analyze
+// packages at all.
+//
+// The modes that do not are the ones that must not be multiplied by the number
+// of modules: printing usage, printing the -flags inventory that "go vet
+// -vettool" reads to learn which flags the tool accepts, and the .cfg dispatch
+// through which "go vet" hands the tool a single prepared unit of work. Running
+// any of those once per module would turn one answer into several, and in the
+// .cfg case would run a per-module expansion inside a driver that has already
+// been told exactly which package to analyze.
+//
+// "go vet" can reach this: -flags advertises every flag registered on the
+// global flag set, this one included, so "go vet -multi-module -vettool=qtlint"
+// parses and forwards the flag to the .cfg invocation. Reaching it is harmless,
+// because that invocation lands here and is passed straight through.
+func analyzes(flags, operands []string) bool {
+	for _, name := range []string{"flags", "h", "help"} {
+		if hasFlag(flags, name) {
+			return false
+		}
+	}
+
+	return !isUnitConfig(operands)
+}
+
+// isUnitConfig reports whether operands are the single .cfg file that "go vet"
+// passes to a vet tool, which is how the analysis driver recognizes that mode.
+func isUnitConfig(operands []string) bool {
+	return len(operands) == 1 && strings.HasSuffix(operands[0], ".cfg")
+}
+
+// hasFlag reports whether args set the named boolean flag to true.
+func hasFlag(args []string, name string) bool {
+	set := false
+
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+
+		argName, value, isFlag := splitFlag(arg)
+		if isFlag && argName == name {
+			set = value != "false"
+		}
+	}
+
+	return set
+}

--- a/internal/modules/merge.go
+++ b/internal/modules/merge.go
@@ -1,0 +1,117 @@
+package modules
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// tree is the JSON document the driver prints under -json: a package
+// identifier, then an analyzer name, then either the list of diagnostics that
+// analyzer produced or an object describing why it produced none.
+//
+// Keeping the innermost value raw is what lets diagnostics travel from a child
+// to the combined document without this package needing to know their fields.
+// A future release of x/tools may add one; it will pass through untouched.
+type tree map[string]map[string]json.RawMessage
+
+// add merges one child's document into t.
+//
+// Two modules producing the same package identifier is not expected — an
+// identifier carries the module path, and two modules with the same path in one
+// repository is a mistake in the repository — but it is possible, and silently
+// dropping one of them would lose diagnostics. Diagnostic lists are therefore
+// concatenated, and an error beats a list, because an error means those
+// packages were never analyzed and that is the more important fact about them.
+func (t tree) add(data []byte) error {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return nil
+	}
+
+	var incoming tree
+	if err := json.Unmarshal(data, &incoming); err != nil {
+		// Refusing here is deliberate. Unparsable output means a module's
+		// result is unknown, and an unknown result that is quietly skipped
+		// leaves a combined document that looks complete.
+		return fmt.Errorf("parse -json output: %w", err)
+	}
+
+	for pkg, analyzers := range incoming {
+		if _, ok := t[pkg]; !ok {
+			t[pkg] = analyzers
+
+			continue
+		}
+
+		for name, value := range analyzers {
+			existing, ok := t[pkg][name]
+			if !ok {
+				t[pkg][name] = value
+
+				continue
+			}
+
+			combined, err := combine(existing, value)
+			if err != nil {
+				return err
+			}
+
+			t[pkg][name] = combined
+		}
+	}
+
+	return nil
+}
+
+// combine joins two values recorded for the same package and analyzer.
+func combine(a, b json.RawMessage) (json.RawMessage, error) {
+	if !isArray(a) {
+		return a, nil
+	}
+
+	if !isArray(b) {
+		return b, nil
+	}
+
+	var first, second []json.RawMessage
+	if err := json.Unmarshal(a, &first); err != nil {
+		return nil, fmt.Errorf("parse diagnostics: %w", err)
+	}
+
+	if err := json.Unmarshal(b, &second); err != nil {
+		return nil, fmt.Errorf("parse diagnostics: %w", err)
+	}
+
+	joined, err := json.Marshal(append(first, second...))
+	if err != nil {
+		return nil, fmt.Errorf("join diagnostics: %w", err)
+	}
+
+	return joined, nil
+}
+
+// isArray reports whether raw holds a JSON array, which is how a list of
+// diagnostics is told apart from the object that reports an error.
+func isArray(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+
+	return len(trimmed) > 0 && trimmed[0] == '['
+}
+
+// print writes the combined document the way the driver writes its own:
+// indented with tabs, keys in the order encoding/json sorts a map into, and a
+// trailing newline. A caller parsing qtlint's -json output cannot tell that more
+// than one process produced it.
+func (t tree) print(w io.Writer) error {
+	data, err := json.MarshalIndent(t, "", "\t")
+	if err != nil {
+		return fmt.Errorf("encode -json output: %w", err)
+	}
+
+	if _, err := fmt.Fprintf(w, "%s\n", data); err != nil {
+		return fmt.Errorf("write -json output: %w", err)
+	}
+
+	return nil
+}

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -54,10 +54,10 @@ const FlagName = "multi-module"
 //
 // Stripping FlagName from the child's arguments is what stops a child from
 // expanding again, and for a boolean flag that stripping is exact: the flag
-// package accepts only "-modules", "--modules" and the "=" spellings, all of
-// which Strip removes. The marker is here because the failure it guards
-// against is a fork bomb rather than a wrong answer, and that is worth a second
-// lock. It is not a user-facing setting.
+// package accepts only "-multi-module", "--multi-module" and the "="
+// spellings, all of which Requested removes. The marker is here because the
+// failure it guards against is a fork bomb rather than a wrong answer, and that
+// is worth a second lock. It is not a user-facing setting.
 const childEnv = "QTLINT_MODULES_CHILD"
 
 // valueFlags are the flags that take their value as a separate argument.
@@ -103,9 +103,9 @@ func ValueFlags() []string {
 // Requested reports whether args ask for multi-module mode, and returns args
 // with the flag removed so a child does not expand again.
 //
-// The value spellings of a boolean flag are honored, so "-modules=false" turns
-// the mode off exactly as the flag package would. A repeated flag takes the
-// last value, which is also what the flag package does.
+// The value spellings of a boolean flag are honored, so "-multi-module=false"
+// turns the mode off exactly as the flag package would. A repeated flag takes
+// the last value, which is also what the flag package does.
 func Requested(args []string) (rest []string, on bool) {
 	rest = make([]string, 0, len(args))
 

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -1,0 +1,203 @@
+// Package modules lets one qtlint invocation cover packages that live in
+// several Go modules.
+//
+// go/packages resolves package patterns by running the go command, and the go
+// command resolves them against the module that contains the working
+// directory. A pattern naming a different module is not a pattern that matches
+// nothing, it is an error:
+//
+//	$ qtlint ./testkit/...
+//	pattern ./testkit/...: directory prefix testkit does not contain main
+//	module or its selected dependencies
+//
+// No spelling avoids this. An absolute path reports the same error, and naming
+// the directory without "..." reports that the main module does not contain
+// that package. A Go workspace does not fix it either: with a go.work listing
+// every module, "./testkit/..." starts working, but "./..." still matches only
+// the module the working directory is in, so the caller is still the one
+// enumerating modules.
+//
+// What does work is the working directory. Run the command inside a module and
+// it analyzes that module correctly. So this package leaves the driver exactly
+// as it is and moves the working directory instead: it finds the modules under
+// the requested patterns, then runs the command once per module, each time with
+// the working directory set to that module and the patterns rewritten to be
+// relative to it.
+//
+// Re-running the command rather than calling the analysis driver in a loop is
+// what keeps the driver whole. golang.org/x/tools/go/analysis/singlechecker
+// parses the global flag set and exits the process; it cannot be entered twice
+// and it never returns. Replacing it would cost -fix, -diff, -json, -c, the
+// -flags inventory that "go vet -vettool" reads, and the .cfg dispatch that
+// makes qtlint usable as a vet tool. Each of those keeps working here because
+// each child is the same command with the same flags.
+package modules
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// FlagName is the command-line flag that turns multi-module mode on.
+//
+// The analysis driver already declares -tags, -source, -v, -all, -c, -test,
+// -json, -diff, -fix, -flags and the profiling flags, and the flag package
+// panics with "flag redefined" on a second registration, so a new flag has to
+// keep clear of every name the driver takes. It also keeps clear of -modules,
+// which reads like a list of module names to analyze rather than a mode, and
+// which golangci-lint has already spent on the unrelated
+// --modules-download-mode.
+const FlagName = "multi-module"
+
+// childEnv marks a process this package started.
+//
+// Stripping FlagName from the child's arguments is what stops a child from
+// expanding again, and for a boolean flag that stripping is exact: the flag
+// package accepts only "-modules", "--modules" and the "=" spellings, all of
+// which Strip removes. The marker is here because the failure it guards
+// against is a fork bomb rather than a wrong answer, and that is worth a second
+// lock. It is not a user-facing setting.
+const childEnv = "QTLINT_MODULES_CHILD"
+
+// valueFlags are the flags that take their value as a separate argument.
+//
+// Splitting flags from package operands needs this and nothing else: a boolean
+// flag never consumes the argument after it, so only these can hide an operand
+// behind them. "qtlint -c 0 ./..." is the shape that matters — a scan that did
+// not know -c takes a value would read "0" as a package pattern.
+//
+// The driver builds its flag set inside singlechecker.Main, which is after the
+// point where this decision has to be made, so the set cannot be read from the
+// driver at run time. TestValueFlagsMatchesTheDriver reads the built binary's
+// own -h output and fails if this table stops matching it, which turns a future
+// x/tools release adding a value-taking flag into a red test rather than a
+// misread command line.
+var valueFlags = map[string]bool{
+	"c":          true,
+	"cpuprofile": true,
+	"debug":      true,
+	"memprofile": true,
+	"tags":       true,
+	"trace":      true,
+}
+
+// ValueFlags returns the driver flags that take their value as a separate
+// argument, sorted.
+//
+// It is exported so that TestValueFlagsMatchesTheDriver, which is next to the
+// command because that is where the binary is built, can compare this list
+// against the flag set the built driver actually prints. Nothing outside the
+// module can see it: this package is internal.
+func ValueFlags() []string {
+	names := make([]string, 0, len(valueFlags))
+	for name := range valueFlags {
+		names = append(names, name)
+	}
+
+	slices.Sort(names)
+
+	return names
+}
+
+// Requested reports whether args ask for multi-module mode, and returns args
+// with the flag removed so a child does not expand again.
+//
+// The value spellings of a boolean flag are honored, so "-modules=false" turns
+// the mode off exactly as the flag package would. A repeated flag takes the
+// last value, which is also what the flag package does.
+func Requested(args []string) (rest []string, on bool) {
+	rest = make([]string, 0, len(args))
+
+	for i, arg := range args {
+		// The flag package stops parsing flags at a bare "--", so a
+		// "-modules" after it is a package pattern rather than a flag.
+		if arg == "--" {
+			rest = append(rest, args[i:]...)
+
+			break
+		}
+
+		name, value, isFlag := splitFlag(arg)
+		if !isFlag || name != FlagName {
+			rest = append(rest, arg)
+
+			continue
+		}
+
+		// A boolean flag never takes the following argument as its value,
+		// so anything not written with "=" is simply true.
+		on = value != "false"
+	}
+
+	return rest, on
+}
+
+// SplitArgs splits args into the leading flags and the package operands that
+// follow them, the way the flag package does.
+//
+// Parsing stops at the first argument that is not a flag and is not the value
+// of one, and everything from there on is an operand. A bare "--" also ends the
+// flags, and is kept with them so that reassembling a command line preserves
+// it.
+func SplitArgs(args []string) (flags, operands []string) {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--" {
+			return args[:i+1], args[i+1:]
+		}
+
+		name, _, isFlag := splitFlag(args[i])
+		if !isFlag {
+			return args[:i], args[i:]
+		}
+
+		// A value written with "=" is part of this argument; otherwise a
+		// value-taking flag swallows the next one.
+		if !strings.Contains(args[i], "=") && valueFlags[name] && i+1 < len(args) {
+			i++
+		}
+	}
+
+	return args, nil
+}
+
+// splitFlag reports whether arg is shaped like a flag and, if so, returns its
+// name and any value joined to it with "=".
+//
+// The flag package accepts one leading dash or two, and treats "-", "--" and
+// anything not starting with a dash as something other than a flag.
+func splitFlag(arg string) (name, value string, ok bool) {
+	if !strings.HasPrefix(arg, "-") {
+		return "", "", false
+	}
+
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(arg, "-"), "-")
+	if trimmed == "" || strings.HasPrefix(trimmed, "-") {
+		return "", "", false
+	}
+
+	name, value, _ = strings.Cut(trimmed, "=")
+
+	return name, value, true
+}
+
+// isDirPattern reports whether pattern names a directory rather than an import
+// path or one of the go command's reserved pattern words.
+//
+// Multi-module mode has to turn a pattern into a set of directories to look for
+// go.mod files in, and only a directory pattern carries that information. An
+// import path such as "example.com/x/..." names packages the go command
+// resolves through the module graph, and "all", "std", "cmd" and "tool" name
+// sets that have no directory root at all. Refusing those is deliberate: the
+// alternative is to analyze whatever subset happens to resolve and exit 0,
+// which is the shape of a run that looks clean because it inspected nothing.
+func isDirPattern(pattern string) bool {
+	if filepath.IsAbs(pattern) {
+		return true
+	}
+
+	cleaned := filepath.ToSlash(pattern)
+
+	return cleaned == "." || cleaned == ".." ||
+		strings.HasPrefix(cleaned, "./") || strings.HasPrefix(cleaned, "../")
+}

--- a/internal/modules/modules_test.go
+++ b/internal/modules/modules_test.go
@@ -1,0 +1,406 @@
+// Package modules_test exercises the multi-module planning through the
+// package's exported surface only. What the command does with a plan is an
+// end-to-end question, and is pinned next to the command in
+// cmd/qtlint/multimodule_test.go by running the built binary; what is here is
+// the part that can be decided without a go command: which arguments are
+// package operands, and which modules a set of patterns reaches.
+package modules_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-extras/qtlint/internal/modules"
+)
+
+func TestRequested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+		on   bool
+	}{{
+		name: "absent",
+		args: []string{"./..."},
+		want: []string{"./..."},
+		on:   false,
+	}, {
+		name: "present",
+		args: []string{"-multi-module", "./..."},
+		want: []string{"./..."},
+		on:   true,
+	}, {
+		name: "two leading dashes",
+		args: []string{"--multi-module", "./..."},
+		want: []string{"./..."},
+		on:   true,
+	}, {
+		name: "set to true",
+		args: []string{"-multi-module=true", "./..."},
+		want: []string{"./..."},
+		on:   true,
+	}, {
+		// The flag package reads -x=false as false, and a mode that
+		// ignored that would be impossible to turn off from a wrapper
+		// script that always passes the flag.
+		name: "set to false",
+		args: []string{"-multi-module=false", "./..."},
+		want: []string{"./..."},
+		on:   false,
+	}, {
+		name: "a repeat takes the last value",
+		args: []string{"-multi-module", "-multi-module=false", "./..."},
+		want: []string{"./..."},
+		on:   false,
+	}, {
+		// Other flags have to survive, because they are what the child
+		// is run with.
+		name: "other flags are kept in order",
+		args: []string{"-c", "0", "-multi-module", "-tags", "integration", "./..."},
+		want: []string{"-c", "0", "-tags", "integration", "./..."},
+		on:   true,
+	}, {
+		// After a bare "--" the flag package is no longer reading flags,
+		// so this is a package pattern that happens to look like one.
+		name: "after a bare double dash it is an operand",
+		args: []string{"--", "-multi-module"},
+		want: []string{"--", "-multi-module"},
+		on:   false,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, on := modules.Requested(tc.args)
+			if on != tc.on {
+				t.Errorf("on = %v, want %v", on, tc.on)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("rest\ngot:  %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		args     []string
+		flags    []string
+		operands []string
+	}{{
+		name:     "no flags",
+		args:     []string{"./..."},
+		flags:    nil,
+		operands: []string{"./..."},
+	}, {
+		name:     "no operands",
+		args:     []string{"-json"},
+		flags:    []string{"-json"},
+		operands: nil,
+	}, {
+		name:     "boolean flag does not swallow the operand",
+		args:     []string{"-fix", "./..."},
+		flags:    []string{"-fix"},
+		operands: []string{"./..."},
+	}, {
+		// The shape that matters. -c takes its value as a separate
+		// argument, so a split that did not know that would read "0" as a
+		// package pattern and plan the whole run around it.
+		name:     "a value taking flag swallows the next argument",
+		args:     []string{"-c", "0", "./..."},
+		flags:    []string{"-c", "0"},
+		operands: []string{"./..."},
+	}, {
+		name:     "a value joined with equals does not swallow",
+		args:     []string{"-c=0", "./..."},
+		flags:    []string{"-c=0"},
+		operands: []string{"./..."},
+	}, {
+		name:     "several operands",
+		args:     []string{"-tags", "integration", "./a/...", "./b/..."},
+		flags:    []string{"-tags", "integration"},
+		operands: []string{"./a/...", "./b/..."},
+	}, {
+		// The flag package stops at "--" and drops it; keeping it with
+		// the flags is what lets a command line be put back together.
+		name:     "a bare double dash ends the flags",
+		args:     []string{"-fix", "--", "-weird"},
+		flags:    []string{"-fix", "--"},
+		operands: []string{"-weird"},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags, operands := modules.SplitArgs(tc.args)
+			if !slices.Equal(flags, tc.flags) {
+				t.Errorf("flags\ngot:  %q\nwant: %q", flags, tc.flags)
+			}
+			if !slices.Equal(operands, tc.operands) {
+				t.Errorf("operands\ngot:  %q\nwant: %q", operands, tc.operands)
+			}
+		})
+	}
+}
+
+func TestPlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// wd is relative to the tree built for the test.
+		wd       string
+		operands []string
+		// want pairs a module directory, relative to the tree, with the
+		// patterns that module is to be given.
+		want map[string][]string
+	}{{
+		name:     "a recursive pattern reaches the modules nested inside",
+		operands: []string{"./..."},
+		want: map[string][]string{
+			".":      {"./..."},
+			"nested": {"./..."},
+			"quiet":  {"./..."},
+		},
+	}, {
+		// Not recursive, so nothing is searched for below: this is the
+		// single package the caller named, and it belongs to one module.
+		name:     "a plain directory names one module",
+		operands: []string{"."},
+		want:     map[string][]string{".": {"."}},
+	}, {
+		name:     "no operands behave as the current directory",
+		operands: nil,
+		want:     map[string][]string{".": {"."}},
+	}, {
+		name:     "a pattern naming a nested module covers only it",
+		operands: []string{"./nested/..."},
+		want:     map[string][]string{"nested": {"./..."}},
+	}, {
+		// The subtree the caller named has to survive: widening this to
+		// "./..." would analyze the whole module they narrowed away from.
+		name:     "a subtree of a module keeps its subtree",
+		operands: []string{"./pkg/..."},
+		want:     map[string][]string{".": {"./pkg/..."}},
+	}, {
+		name:     "several patterns are a union",
+		operands: []string{"./nested/...", "./pkg/..."},
+		want: map[string][]string{
+			".":      {"./pkg/..."},
+			"nested": {"./..."},
+		},
+	}, {
+		// One module reached twice is one run, not two.
+		name:     "a module named twice is planned once",
+		operands: []string{"./nested/...", "./nested/sub"},
+		want:     map[string][]string{"nested": {"./...", "./sub"}},
+	}, {
+		name:     "a pattern written from inside a nested module",
+		wd:       "nested",
+		operands: []string{"./..."},
+		want:     map[string][]string{"nested": {"./..."}},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tree := buildTree(t)
+
+			runs, err := modules.Plan(filepath.Join(tree, tc.wd), tc.operands)
+			if err != nil {
+				t.Fatalf("Plan: %v", err)
+			}
+
+			got := make(map[string][]string, len(runs))
+			for _, run := range runs {
+				rel, err := filepath.Rel(tree, run.Dir)
+				if err != nil {
+					t.Fatalf("relate %s: %v", run.Dir, err)
+				}
+
+				got[filepath.ToSlash(rel)] = run.Patterns
+			}
+
+			if len(got) != len(tc.want) {
+				t.Errorf("modules\ngot:  %v\nwant: %v", got, tc.want)
+			}
+
+			for dir, want := range tc.want {
+				if !slices.Equal(got[dir], want) {
+					t.Errorf("patterns for %s\ngot:  %q\nwant: %q", dir, got[dir], want)
+				}
+			}
+		})
+	}
+}
+
+// TestPlanSkipsDirectoriesTheGoCommandIgnores pins the walk against the go
+// command's own rules for expanding "...". A module under testdata or vendor,
+// or under a directory whose name starts with "." or "_", is not part of what
+// "./..." means, and analyzing it would report diagnostics from files the
+// caller never asked about — a linter's own fixtures, most of all.
+func TestPlanSkipsDirectoriesTheGoCommandIgnores(t *testing.T) {
+	t.Parallel()
+
+	tree := buildTree(t)
+
+	for _, dir := range []string{"testdata/mod", "vendor/mod", ".hidden/mod", "_work/mod"} {
+		writeModule(t, filepath.Join(tree, filepath.FromSlash(dir)), "ignored.test/"+filepath.Base(dir))
+	}
+
+	runs, err := modules.Plan(tree, []string{"./..."})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	for _, run := range runs {
+		rel, err := filepath.Rel(tree, run.Dir)
+		if err != nil {
+			t.Fatalf("relate %s: %v", run.Dir, err)
+		}
+
+		for _, ignored := range []string{"testdata", "vendor", ".hidden", "_work"} {
+			if strings.HasPrefix(filepath.ToSlash(rel), ignored+"/") {
+				t.Errorf("planned a run in %s, which the go command ignores", rel)
+			}
+		}
+	}
+}
+
+// TestPlanFindsModulesWithNoModuleAbove covers a repository that is a container
+// of modules rather than a module. The go command cannot analyze it at all
+// today — there is no main module to run in — so every module in it has to come
+// from the downward search.
+func TestPlanFindsModulesWithNoModuleAbove(t *testing.T) {
+	t.Parallel()
+
+	tree := t.TempDir()
+	writeModule(t, filepath.Join(tree, "alpha"), "container.test/alpha")
+	writeModule(t, filepath.Join(tree, "beta"), "container.test/beta")
+
+	runs, err := modules.Plan(tree, []string{"./..."})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	var got []string
+	for _, run := range runs {
+		rel, err := filepath.Rel(tree, run.Dir)
+		if err != nil {
+			t.Fatalf("relate %s: %v", run.Dir, err)
+		}
+
+		got = append(got, filepath.ToSlash(rel))
+	}
+
+	want := []string{"alpha", "beta"}
+	if !slices.Equal(got, want) {
+		t.Errorf("modules\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+// TestPlanRefusesPatternsWithNoDirectory pins the refusal. These patterns name
+// packages through the module graph or through a reserved word, so there is no
+// directory to search for modules under. Planning whatever part of them happens
+// to resolve would report a subset and exit 0.
+func TestPlanRefusesPatternsWithNoDirectory(t *testing.T) {
+	t.Parallel()
+
+	tree := buildTree(t)
+
+	for _, operand := range []string{"all", "std", "example.com/x/...", "example.com/x"} {
+		t.Run(operand, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := modules.Plan(tree, []string{operand}); err == nil {
+				t.Errorf("Plan(%q) succeeded, want a refusal", operand)
+			}
+		})
+	}
+}
+
+// TestPlanReportsWhenNothingIsAModule checks that an empty answer is an error
+// rather than an empty plan. A plan with no runs would exit 0 having analyzed
+// nothing, which is indistinguishable from a clean repository.
+func TestPlanReportsWhenNothingIsAModule(t *testing.T) {
+	t.Parallel()
+
+	if _, err := modules.Plan(t.TempDir(), []string{"./..."}); err == nil {
+		t.Error("Plan succeeded with no module anywhere, want a refusal")
+	}
+}
+
+// TestPlanIsOrdered checks that the runs come back in a stable order. Two runs
+// of the same command line have to report modules in the same order, or their
+// outputs cannot be compared to each other.
+func TestPlanIsOrdered(t *testing.T) {
+	t.Parallel()
+
+	tree := buildTree(t)
+
+	first, err := modules.Plan(tree, []string{"./..."})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	second, err := modules.Plan(tree, []string{"./..."})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	if !slices.EqualFunc(first, second, func(a, b modules.Run) bool { return a.Dir == b.Dir }) {
+		t.Errorf("two plans disagree\nfirst:  %v\nsecond: %v", first, second)
+	}
+
+	if !slices.IsSortedFunc(first, func(a, b modules.Run) int { return strings.Compare(a.Dir, b.Dir) }) {
+		t.Errorf("plan is not ordered: %v", first)
+	}
+}
+
+// buildTree writes the module layout the planning tests share:
+//
+//	.           a module, with a plain package in pkg
+//	./nested    a module inside it, with a package in sub
+//	./quiet     a second module inside it
+func buildTree(t *testing.T) string {
+	t.Helper()
+
+	tree := t.TempDir()
+
+	writeModule(t, tree, "tree.test/outer")
+	writeModule(t, filepath.Join(tree, "nested"), "tree.test/nested")
+	writeModule(t, filepath.Join(tree, "quiet"), "tree.test/quiet")
+
+	for _, dir := range []string{"pkg", filepath.Join("nested", "sub")} {
+		if err := os.MkdirAll(filepath.Join(tree, dir), 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+
+	return tree
+}
+
+// writeModule makes dir a module root.
+func writeModule(t *testing.T, dir, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+
+	body := "module " + path + "\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write go.mod in %s: %v", dir, err)
+	}
+}

--- a/internal/modules/modules_test.go
+++ b/internal/modules/modules_test.go
@@ -7,8 +7,10 @@
 package modules_test
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -365,6 +367,43 @@ func TestPlanIsOrdered(t *testing.T) {
 
 	if !slices.IsSortedFunc(first, func(a, b modules.Run) int { return strings.Compare(a.Dir, b.Dir) }) {
 		t.Errorf("plan is not ordered: %v", first)
+	}
+}
+
+// TestExecuteNormalizesASignalledChild pins the exit code when a module run is
+// killed rather than finishing.
+//
+// A signal leaves no exit code, and ExitCode reports -1 for it. Returning that
+// reaches os.Exit, where a negative value becomes a status the caller's shell
+// reads as something else entirely — 255 on Unix — which is neither the
+// driver's 0, 1 nor 3. The module was not analyzed, so it counts as a failure.
+func TestExecuteNormalizesASignalledChild(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("the child is a POSIX shell that signals itself")
+	}
+
+	runs := []modules.Run{{Dir: t.TempDir(), Patterns: []string{"./..."}}}
+
+	code, err := modules.Execute(runs, modules.Options{
+		// A child that kills itself, standing in for one the operating
+		// system kills. Patterns are appended to Flags, and the shell
+		// ignores them.
+		Exe:    "/bin/sh",
+		Flags:  []string{"-c", "kill -9 $$"},
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if code < 0 {
+		t.Errorf("exit code = %d, which os.Exit cannot report faithfully", code)
+	}
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1: a module that was killed was not analyzed", code)
 	}
 }
 

--- a/internal/modules/plan.go
+++ b/internal/modules/plan.go
@@ -1,0 +1,246 @@
+package modules
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// goMod is the file whose presence makes a directory a module root.
+const goMod = "go.mod"
+
+// Run is one invocation of the command: the module directory to run it in, and
+// the package patterns to give it, already written relative to that directory.
+type Run struct {
+	// Dir is the absolute path of the module root.
+	Dir string
+	// Patterns are the package patterns for this module, sorted.
+	Patterns []string
+}
+
+// request is one package pattern reduced to what planning needs: the directory
+// it is rooted at, and whether it sweeps the tree below that directory.
+type request struct {
+	root      string
+	recursive bool
+}
+
+// Plan returns the runs that cover operands across every module under them,
+// with operands interpreted relative to wd.
+//
+// The result is ordered by directory so that a run of qtlint reports modules in
+// the same order every time. Two runs of the same command line then produce
+// output in the same order, which is what lets one be compared to the other.
+func Plan(wd string, operands []string) ([]Run, error) {
+	if len(operands) == 0 {
+		// The driver analyzes the current directory when given no operands.
+		operands = []string{"."}
+	}
+
+	patterns := make(map[string][]string)
+
+	for _, operand := range operands {
+		if !isDirPattern(operand) {
+			return nil, fmt.Errorf(
+				"-%s needs directory patterns, and %q is not one: "+
+					"write ./... or a path beginning with ./, ../ or /",
+				FlagName, operand)
+		}
+
+		req := splitPattern(operand)
+
+		root, err := filepath.Abs(filepath.Join(wd, filepath.FromSlash(req.root)))
+		if err != nil {
+			return nil, fmt.Errorf("resolve %q: %w", operand, err)
+		}
+
+		req.root = root
+
+		dirs, err := modulesUnder(req)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, dir := range dirs {
+			pattern, err := patternFor(dir, req)
+			if err != nil {
+				return nil, err
+			}
+
+			patterns[dir] = append(patterns[dir], pattern)
+		}
+	}
+
+	if len(patterns) == 0 {
+		return nil, fmt.Errorf(
+			"no module found for %s: expected a %s in one of those directories or above them",
+			strings.Join(quoteAll(operands), ", "), goMod)
+	}
+
+	runs := make([]Run, 0, len(patterns))
+	for dir, dirPatterns := range patterns {
+		slices.Sort(dirPatterns)
+		runs = append(runs, Run{Dir: dir, Patterns: slices.Compact(dirPatterns)})
+	}
+
+	slices.SortFunc(runs, func(a, b Run) int { return strings.Compare(a.Dir, b.Dir) })
+
+	return runs, nil
+}
+
+// splitPattern separates the directory part of a package pattern from the "..."
+// that makes it recursive.
+func splitPattern(pattern string) request {
+	cleaned := filepath.ToSlash(pattern)
+
+	switch {
+	case cleaned == "...":
+		return request{root: ".", recursive: true}
+	case strings.HasSuffix(cleaned, "/..."):
+		return request{root: strings.TrimSuffix(cleaned, "/..."), recursive: true}
+	default:
+		return request{root: cleaned}
+	}
+}
+
+// modulesUnder returns the module directories a request reaches.
+//
+// Two searches answer that, and both are needed. Walking up finds the module
+// the pattern sits inside, which is the module a non-recursive pattern names
+// and the one that owns the packages between the root and the next module below
+// it. Walking down finds the modules nested under the root, which is the half
+// the go command cannot express at all. A repository whose top directory holds
+// no go.mod is covered by the second search alone, so it needs no module of its
+// own.
+func modulesUnder(req request) ([]string, error) {
+	var dirs []string
+
+	if dir, ok := containingModule(req.root); ok {
+		dirs = append(dirs, dir)
+	}
+
+	if !req.recursive {
+		return dirs, nil
+	}
+
+	err := filepath.WalkDir(req.root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			// A directory that cannot be read is reported rather than
+			// skipped. Silently walking past it would drop every module
+			// under it, and a module that was never analyzed must not be
+			// indistinguishable from one that was analyzed and was clean.
+			return err
+		}
+
+		if !entry.IsDir() {
+			return nil
+		}
+
+		// The go command ignores these when expanding "...", so a pattern
+		// that reached them here would analyze packages that "./..." never
+		// does. The root itself is exempt: naming such a directory outright
+		// is a different request from sweeping into it.
+		if path != req.root && isIgnoredDir(entry.Name()) {
+			return filepath.SkipDir
+		}
+
+		// The walk continues into a module it has found, because a module
+		// may hold further modules and each is its own analysis.
+		if isModuleRoot(path) {
+			dirs = append(dirs, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("search %s for modules: %w", req.root, err)
+	}
+
+	slices.Sort(dirs)
+
+	return slices.Compact(dirs), nil
+}
+
+// isIgnoredDir reports whether the go command ignores a directory of this name
+// when it expands a "..." pattern.
+func isIgnoredDir(name string) bool {
+	return strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") ||
+		name == "testdata" || name == "vendor"
+}
+
+// containingModule returns the innermost module directory at or above dir.
+func containingModule(dir string) (string, bool) {
+	for {
+		if isModuleRoot(dir) {
+			return dir, true
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+
+		dir = parent
+	}
+}
+
+// isModuleRoot reports whether dir holds a go.mod file.
+func isModuleRoot(dir string) bool {
+	info, err := os.Stat(filepath.Join(dir, goMod))
+
+	return err == nil && info.Mode().IsRegular()
+}
+
+// patternFor writes the part of a request that belongs to the module rooted at
+// dir, relative to that module.
+//
+// A module found below the root receives the whole of its own tree. The module
+// that contains the root receives the subtree the caller actually named, which
+// is what keeps "qtlint -multi-module ./cmd/..." from widening to the whole
+// module. Packages belonging to a module nested inside this one need no
+// excluding: the go command already leaves them out of a pattern expanded in
+// the parent.
+func patternFor(dir string, req request) (string, error) {
+	rel, err := filepath.Rel(dir, req.root)
+	if err != nil {
+		return "", fmt.Errorf("relate %s to %s: %w", req.root, dir, err)
+	}
+
+	rel = filepath.ToSlash(rel)
+
+	// The module sits below the root, so the request covers the whole of it.
+	// Only the downward search reaches such a module, and it only runs for a
+	// recursive request.
+	if rel == ".." || strings.HasPrefix(rel, "../") {
+		return "./...", nil
+	}
+
+	// The module is the one the pattern was written in.
+	if rel == "." {
+		if req.recursive {
+			return "./...", nil
+		}
+
+		return ".", nil
+	}
+
+	// The module contains the root, so it receives just the named subtree.
+	if req.recursive {
+		return "./" + rel + "/...", nil
+	}
+
+	return "./" + rel, nil
+}
+
+// quoteAll quotes each string for an error message.
+func quoteAll(values []string) []string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, fmt.Sprintf("%q", value))
+	}
+
+	return quoted
+}

--- a/internal/modules/plan.go
+++ b/internal/modules/plan.go
@@ -96,9 +96,12 @@ func Plan(wd string, operands []string) ([]Run, error) {
 func splitPattern(pattern string) request {
 	cleaned := filepath.ToSlash(pattern)
 
+	// A bare "..." never arrives here: isDirPattern refuses it, because the
+	// go command reads it as every package it can reach rather than every
+	// package below the working directory. "go list ..." in this repository
+	// prints archive/tar, bufio and the rest of the standard library. Quietly
+	// reading it as "./..." would narrow what the caller asked for.
 	switch {
-	case cleaned == "...":
-		return request{root: ".", recursive: true}
 	case strings.HasSuffix(cleaned, "/..."):
 		return request{root: strings.TrimSuffix(cleaned, "/..."), recursive: true}
 	default:

--- a/internal/modules/run.go
+++ b/internal/modules/run.go
@@ -32,6 +32,7 @@ type Options struct {
 // distinction rather than flattening every non-zero result into one.
 const (
 	exitClean       = 0
+	exitFailed      = 1
 	exitDiagnostics = 3
 )
 
@@ -123,6 +124,14 @@ func execute(run Run, opts Options) (code int, stdout []byte, err error) {
 	switch err := cmd.Run(); {
 	case errors.As(err, &exitErr):
 		code = exitErr.ExitCode()
+
+		// A signal leaves no exit code and ExitCode reports -1, which
+		// os.Exit would turn into a status the caller's shell reads as
+		// something else entirely. The module was not analyzed, so it is
+		// reported as the failure it is.
+		if code < 0 {
+			code = exitFailed
+		}
 	case err != nil:
 		return 0, nil, fmt.Errorf("run in %s: %w", run.Dir, err)
 	}

--- a/internal/modules/run.go
+++ b/internal/modules/run.go
@@ -1,0 +1,131 @@
+package modules
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+)
+
+// Options describe how Execute runs the plan.
+type Options struct {
+	// Exe is the command to re-run, normally the running binary.
+	Exe string
+	// Flags are the arguments to give every child, with the multi-module
+	// flag already removed and the package operands not yet appended.
+	Flags []string
+	// JSON reports whether -json was requested, which changes both what a
+	// child's standard output means and how the results combine.
+	JSON bool
+	// Stdout and Stderr are where a child's output goes.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Exit codes of the analysis driver, established by running it.
+//
+// The driver reports diagnostics with 3 and a package it could not analyze with
+// 1, and it is careful to distinguish them. Aggregating has to preserve that
+// distinction rather than flattening every non-zero result into one.
+const (
+	exitClean       = 0
+	exitDiagnostics = 3
+)
+
+// Execute runs each entry of the plan and returns the exit code for the whole
+// invocation.
+//
+// The code is the worst news any module produced. A module the driver could not
+// analyze outranks a module with diagnostics, because a failed load means the
+// packages were never inspected and reporting that as a mere finding would
+// describe work that did not happen. Diagnostics in turn outrank a clean
+// module, so a single clean module can never carry the invocation to 0. This is
+// the property that makes a multi-module run usable in CI at all.
+//
+// Exit codes are otherwise the driver's own, unchanged: 0 when every module is
+// clean, 3 when some module reported diagnostics, and whatever the driver
+// returned when it failed. In -json mode the driver itself exits 0 even with
+// diagnostics, reporting them in the document instead, and that is preserved
+// here rather than corrected.
+func Execute(runs []Run, opts Options) (int, error) {
+	merged := make(tree)
+
+	worst := exitClean
+
+	for _, run := range runs {
+		code, out, err := execute(run, opts)
+		if err != nil {
+			return 0, err
+		}
+
+		if opts.JSON {
+			if err := merged.add(out); err != nil {
+				return 0, fmt.Errorf("module %s: %w", run.Dir, err)
+			}
+		}
+
+		switch {
+		case code == exitClean:
+		case code == exitDiagnostics && worst == exitClean:
+			worst = exitDiagnostics
+		case code != exitDiagnostics:
+			// A driver failure ends the aggregation as the answer, but
+			// every module still runs: the caller asked about all of
+			// them, and stopping early would hide findings that a later
+			// module was about to report.
+			if worst == exitClean || worst == exitDiagnostics {
+				worst = code
+			}
+		}
+	}
+
+	if opts.JSON {
+		if err := merged.print(opts.Stdout); err != nil {
+			return 0, err
+		}
+	}
+
+	return worst, nil
+}
+
+// execute runs one module and returns its exit code, plus its standard output
+// when that output is a JSON document this package has to combine.
+//
+// Outside -json mode the child writes straight through to the parent's streams.
+// The driver prints diagnostics to standard error and JSON to standard output,
+// so nothing is buffered that a caller might be watching: a long multi-module
+// run reports each module as it finishes rather than at the end.
+func execute(run Run, opts Options) (code int, stdout []byte, err error) {
+	args := append(slices.Clone(opts.Flags), run.Patterns...)
+
+	// The command is this program and the arguments are the ones it was
+	// given, with the module's own patterns in place of the caller's. Neither
+	// is attacker-controlled in any sense the caller does not already have:
+	// anyone who can choose them can run the binary directly.
+	//nolint:gosec // re-running this same binary is the mechanism, not a risk
+	cmd := exec.Command(opts.Exe, args...)
+	cmd.Dir = run.Dir
+	cmd.Env = append(os.Environ(), childEnv+"=1")
+	cmd.Stderr = opts.Stderr
+
+	var buf bytes.Buffer
+	if opts.JSON {
+		cmd.Stdout = &buf
+	} else {
+		cmd.Stdout = opts.Stdout
+	}
+
+	var exitErr *exec.ExitError
+
+	switch err := cmd.Run(); {
+	case errors.As(err, &exitErr):
+		code = exitErr.ExitCode()
+	case err != nil:
+		return 0, nil, fmt.Errorf("run in %s: %w", run.Dir, err)
+	}
+
+	return code, buf.Bytes(), nil
+}


### PR DESCRIPTION
## What

`qtlint ./...` analyzes exactly one module: the one holding the working directory. Packages in any other module are not reported as missing, they are simply absent, so a repository of several modules can be linted for months while most of it is never inspected.

`-multi-module` makes one invocation cover them all.

```bash
qtlint -multi-module ./...
qtlint -multi-module -tags integration ./...
```

## Why the loader, not the analyzer

`go/packages` resolves patterns by running the `go` command, and the `go` command resolves them against the main module. Measured on a repository whose `testkit/` is a separate module:

| spelling | result |
| --- | --- |
| `./testkit/...` | exit 1 — `directory prefix testkit does not contain main module or its selected dependencies` |
| `/abs/path/testkit/...` | exit 1 — same error |
| `./testkit` | exit 1 — `main module (…) does not contain package …/testkit` |
| `./...` from the root | exit 0, silently covering only the root module |

A Go workspace does not fix it. With a `go.work` listing every module, `./testkit/...` starts working — but `./...` still matches only the module the caller stands in, so the caller is still enumerating modules by hand. That was measured too, not assumed.

The binary itself was never the problem: run with the working directory inside `testkit`, it analyzes that module correctly. So this moves the working directory rather than touching the analyzer.

## How

`-multi-module` finds every `go.mod` at or under the directories named, then re-runs the command once per module with the working directory set to it.

**Re-running rather than looping in-process is what keeps the driver whole.** `singlechecker.Main` parses the global flag set and exits without returning, so it cannot be entered twice, and replacing it would cost `-fix`, `-diff`, `-json`, `-c`, the `-flags` inventory that `go vet -vettool` reads, and the `.cfg` dispatch — the same reasoning that kept #67 from writing a custom driver. Each child is the same command with the same flags, so each of those keeps working.

Details worth review:

- **Discovery, not a list.** A module added next month is covered without anyone remembering to add it. Directories the `go` command ignores when expanding `...` — `vendor`, `testdata`, and names beginning with `.` or `_` — are ignored here too. A repository whose top level holds no `go.mod` works: every module comes from the downward search.
- **Exit codes aggregate so the worst news wins.** A module that could not be analyzed (`1`) outranks one with diagnostics (`3`), because its packages were never inspected; a clean module can never bring the invocation back to `0`. `-json` still exits 0 with diagnostics, as the driver does.
- **`-json` is combined into one document**, so anything parsing the output need not know how many processes produced it.
- **Paths stay absolute**, which is what they already were. Each module is analyzed from its own working directory, so a relative path would mean a different file depending on which module produced it.
- **Modes that do not analyze packages are exempt** from the expansion: `-h`, `-flags`, and the `.cfg` dispatch. `go vet` reads `-flags`, so it accepts `-multi-module` and forwards it to the `.cfg` invocation; that invocation passes straight through.

## Both contours still need running

```bash
qtlint -multi-module ./...
qtlint -multi-module -tags integration ./...
```

Two invocations, deliberately. A build tag only ever *adds* files to a build, so satisfying `integration` pulls in `//go:build integration` files and drops `//go:build !integration` ones — neither run is a superset of the other. qtlint does not guess which tag sets a repository means: an unsatisfied constraint is indistinguishable from a nonexistent one, so a tool inventing combinations would analyze builds nobody ships. Naming the contours stays with the caller; naming the modules does not.

The fixture pins this. `contour/integration_test.go` and `contour/plain_test.go` carry opposite constraints, and `TestNeitherContourAloneReportsEverything` requires that each run misses the other's file and that only the union reports all five violations.

## Prior art

`golangci-lint` has no native multi-module support — [#828](https://github.com/golangci/golangci-lint/issues/828) has been open since 2019, and the maintainer position is that it "should be run inside a module", one invocation per module. The closest equivalent is in the official GitHub Action, not the CLI: `experimental: automatic-module-directories` ([action#1315](https://github.com/golangci/golangci-lint-action/pull/1315)), which runs golangci-lint in each module directory, sequentially. That is the same shape as this change, arrived at independently.

On path attribution, golangci-lint reports relative paths and later added `output.path-mode: abs` because users running it over several projects could not tell which project a finding came from ([#5649](https://github.com/golangci/golangci-lint/issues/5649)). Keeping absolute paths here avoids that.

## Evidence

- **The end-to-end test is RED against v1.9.0.** Run against pristine pre-change production code with only the new test file and fixture added: 16 pass, 19 fail. The acceptance control — *"without the flag only the module holding the pattern is seen"* — passes on both sides, so it pins the fixture rather than the feature. All four pre-existing `-tags` tests also pass there, so the shared-harness change did not weaken them.
- **Twelve mutants**, each the cheaper wrong implementation, each compiling, each applied and watched fail, reverted and watched pass: dropping the upward module search; widening a named subtree to the whole module; taking the last module's exit code instead of the worst; inverting the failure/diagnostics precedence; treating every flag as boolean; detecting the flag but leaving it in the child's arguments; forgetting `testdata`/`vendor`; streaming child JSON instead of merging it; dropping the `-flags` exemption; dropping the `.cfg` exemption; accepting any operand as a directory pattern; passing a signalled child's `-1` straight through.

  **Three survived on the first attempt**, and each exposed a fixture that could not tell the mutant from the original:

  - the `-flags` test passed no pattern, so only one module was ever planned and the missing exemption was invisible — it now uses `./...`, and a `.cfg` case was added beside it;
  - the exit-code precedence fixture had the failing module sorting *last*, where "worst wins" and "last wins" agree — a third module named to sort after it now carries a violation;
  - a mutant reverted with `git checkout --` took an uncommitted fix with it, which showed up as a GREEN run that stayed red rather than as a passing mutant.

- **Single-module behavior is unchanged.** Over the frozen `testdata/src` corpus, the v1.9.0 and new binaries produce byte-identical output and identical exit codes in every mode tried — no flags, `-json`, `-c 2`, `-fix -diff`, `-require-qt-c-receiver`, `-require-testing-run`, `-only-stable-fixes`, `-test=false`, `-tags qtprobe`. The single exception is `-flags`, which gains exactly one entry for the new flag.

## Review follow-ups in this branch

Four corrections landed after the first review pass:

- A child killed by a signal has no exit code and `ExitCode` reports `-1`; that reached `os.Exit`, where a negative status is reinterpreted (255 on Unix). It is now reported as the failure it is, and `Execute` is exercised directly by a child that signals itself.
- A bare `...` was refused while `splitPattern` still carried an unreachable branch reading it as `./...`. Refusing is the correct half to keep — measured: `go list ...` prints `archive/tar`, `bufio` and the rest of the standard library, so reading it as `./...` would quietly narrow the request. The dead branch is gone.
- Two comments still named the flag `-modules` from before the rename, and one named a function that no longer exists.
- The README claimed a build tag "only ever adds files" one clause before explaining that satisfying a tag *drops* the `!integration` files. A tag selects a different build rather than a wider one, which is the whole reason both contours are worth running.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race ./... -count=1`, `golangci-lint run ./...`, and `go mod tidy` followed by `git diff --exit-code go.mod go.sum` — each run unpiped, each exit code read directly, all 0.

`-race` caught a real bug during development: capturing stdout through a wrapper broke the `Stdout == Stderr` identity that `os/exec` relies on to serialize writes, so both streams raced on one buffer. The harness now captures them separately.

## Docs

README gains a `-multi-module` section covering the failure it fixes, the `go.work` non-answer, the exit-code table, why paths are absolute, and why both tag contours are worth running. The golangci-lint section notes that multi-module is a golangci-lint concern in that mode.
