### PR TITLE
feat: two rules that close the checker-attribution gap

### DIFF
--- a/qtlint.go
+++ b/qtlint.go
@@ -71,6 +71,14 @@ type analyzer struct {
 	// per-subtest qt.New rather than as c.Run. It is off by default: c.Run is
 	// a legitimate quicktest API and some projects prefer it.
 	requireTestingRun bool
+
+	// requireTestingHandle enables the opt-in house-style rule that requires
+	// a test helper to take testing.TB rather than *qt.C.
+	requireTestingHandle bool
+
+	// requireSubtestChecker enables the opt-in house-style rule that requires
+	// a subtest to assert through its own *qt.C.
+	requireSubtestChecker bool
 }
 
 // NewAnalyzer creates a new instance of the qtlint analyzer.
@@ -89,6 +97,10 @@ func NewAnalyzer() *analysis.Analyzer {
 	aa.Flags.BoolVar(&a.requireQtCReceiver, "require-qt-c-receiver", false,
 		"house-style rule, off by default: report qt.Assert(t, ...) and "+
 			"qt.Check(t, ...) and suggest the *qt.C method form")
+	aa.Flags.BoolVar(&a.requireSubtestChecker, "require-subtest-checker", false,
+		"report a subtest that asserts through the enclosing test's *qt.C (opt-in)")
+	aa.Flags.BoolVar(&a.requireTestingHandle, "require-testing-handle", false,
+		"report a test helper that takes a *qt.C and suggest testing.TB (opt-in)")
 	aa.Flags.BoolVar(&a.requireTestingRun, "require-testing-run", false,
 		"house-style rule, off by default: report c.Run(...) subtests and "+
 			"suggest t.Run(name, func(t *testing.T)) with a per-subtest qt.New")
@@ -184,6 +196,12 @@ func inSourceOrder(pass *analysis.Pass, rules func()) {
 // WithStack traversal. -require-testing-run needs a whole function at once
 // rather than one call at a time, so it walks the files itself.
 func (a *analyzer) runOptInRules(pass *analysis.Pass, insp *inspector.Inspector) {
+	if a.requireTestingHandle {
+		a.checkRequireTestingHandle(pass)
+	}
+	if a.requireSubtestChecker {
+		a.checkRequireSubtestChecker(pass)
+	}
 	if a.requireTestingRun {
 		a.checkRequireTestingRun(pass)
 	}

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -94,4 +94,13 @@ func TestFixes(t *testing.T) {
 		setFlag(t, analyzer, "only-stable-fixes")
 		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "testingrunonlystable")
 	})
+
+	// A subtest asserting through the checker of the test around it. Neither
+	// other rule sees the shape: there is no c.Run to rewrite and the
+	// assertion already goes through a receiver.
+	t.Run("subtestchecker", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-subtest-checker")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "subtestcheckerfix")
+	})
 }

--- a/requiresubtestchecker.go
+++ b/requiresubtestchecker.go
@@ -126,12 +126,12 @@ func planBorrowedCheckers(pass *analysis.Pass, root ast.Node, qtAlias string) {
 		if survivingBorrowUses(pass, root, obj, sites) > 0 {
 			continue
 		}
-		edits, ok := declRemovalEdits(pass, root, obj)
-		if !ok {
+		edits, reason := declRemovalEdits(pass, root, obj)
+		if reason != "" {
 			for _, s := range sites {
 				if s.obj == obj {
 					s.fixable = false
-					s.reason = "; no fix: the checker's declaration shares its line, so removing it would take that with it"
+					s.reason = reason
 				}
 			}
 			continue
@@ -304,26 +304,45 @@ func survivingBorrowUses(pass *analysis.Pass, root ast.Node, obj types.Object, s
 	return count
 }
 
-// declRemovalEdits renders the removal of obj's declaration.
-func declRemovalEdits(pass *analysis.Pass, root ast.Node, obj types.Object) ([]analysis.TextEdit, bool) {
+// declRemovalEdits renders the removal of obj's declaration, and says why it
+// could not when it could not.
+//
+// Both spellings a checker is declared with are handled: c := qt.New(t) is an
+// assignment and var c = qt.New(t) a declaration statement. Answering only the
+// first would leave a var-declared checker reported with a cause that is not
+// its own.
+func declRemovalEdits(pass *analysis.Pass, root ast.Node, obj types.Object) ([]analysis.TextEdit, string) {
 	var decl ast.Node
 	ast.Inspect(root, func(n ast.Node) bool {
-		assign, ok := n.(*ast.AssignStmt)
-		if !ok || len(assign.Lhs) != 1 {
-			return true
-		}
-		ident, ok := assign.Lhs[0].(*ast.Ident)
-		if ok && pass.TypesInfo.Defs[ident] == obj {
-			decl = assign
+		switch d := n.(type) {
+		case *ast.AssignStmt:
+			if len(d.Lhs) != 1 {
+				return true
+			}
+			if ident, ok := d.Lhs[0].(*ast.Ident); ok && pass.TypesInfo.Defs[ident] == obj {
+				decl = d
+			}
+		case *ast.DeclStmt:
+			gen, ok := d.Decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR || len(gen.Specs) != 1 {
+				return true
+			}
+			spec, ok := gen.Specs[0].(*ast.ValueSpec)
+			if !ok || len(spec.Names) != 1 {
+				return true
+			}
+			if pass.TypesInfo.Defs[spec.Names[0]] == obj {
+				decl = d
+			}
 		}
 		return true
 	})
 	if decl == nil {
-		return nil, false
+		return nil, "; no fix: the checker's declaration is not a shape this rule can remove, and it would be left with no reader"
 	}
 	start, end, ok := wholeLineSpan(pass, decl)
 	if !ok {
-		return nil, false
+		return nil, "; no fix: the checker's declaration shares its line, so removing it would take that with it"
 	}
-	return []analysis.TextEdit{{Pos: start, End: end}}, true
+	return []analysis.TextEdit{{Pos: start, End: end}}, ""
 }

--- a/requiresubtestchecker.go
+++ b/requiresubtestchecker.go
@@ -1,0 +1,329 @@
+package qtlint
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// subtestClosure describes a t.Run, b.Run or f.Fuzz closure together with the
+// test handle it is given.
+type subtestClosure struct {
+	// lit is the closure and param its *testing.T parameter.
+	lit   *ast.FuncLit
+	param *ast.Field
+	// handle is the parameter's name. It is empty when the parameter is blank
+	// or unnamed, and the closure then has no handle to build a checker from.
+	handle string
+}
+
+// matchSubtestClosure parses call into a subtestClosure.
+//
+// The receiver is not required to resolve to a testing.TB. A custom runner
+// that takes a func(*testing.T) hands the closure a test handle whatever the
+// receiver's type, and requiring the receiver to type-check silences real
+// violations wherever it is a struct field, an embedded wrapper or a call
+// result — shapes a single-file pass cannot see through. What the rule needs
+// is the closure's own handle, and the signature is what carries that.
+func matchSubtestClosure(pass *analysis.Pass, call *ast.CallExpr) (subtestClosure, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return subtestClosure{}, false
+	}
+	switch sel.Sel.Name {
+	case "Run", "Fuzz":
+	default:
+		return subtestClosure{}, false
+	}
+	if len(call.Args) == 0 {
+		return subtestClosure{}, false
+	}
+
+	lit, ok := call.Args[len(call.Args)-1].(*ast.FuncLit)
+	if !ok {
+		return subtestClosure{}, false
+	}
+	params := lit.Type.Params
+	if params == nil || len(params.List) == 0 {
+		return subtestClosure{}, false
+	}
+	param := params.List[0]
+	if len(param.Names) > 1 || !isTestingTPtr(pass.TypesInfo.TypeOf(param.Type)) {
+		return subtestClosure{}, false
+	}
+
+	closure := subtestClosure{lit: lit, param: param}
+	if len(param.Names) == 1 && param.Names[0].Name != "_" {
+		closure.handle = param.Names[0].Name
+	}
+	return closure, true
+}
+
+// checkRequireSubtestChecker reports a subtest closure that asserts through a
+// *qt.C belonging to the test around it.
+//
+// The shape compiles and passes, which is what makes it worth a rule. A
+// checker reports against whichever test it was built from, so a subtest
+// asserting through its parent's checker names the parent in the failure and,
+// on Assert, stops the parent rather than the subtest. Neither of the other
+// two rules sees it: there is no c.Run to rewrite and the assertion already
+// goes through a receiver.
+func (*analyzer) checkRequireSubtestChecker(pass *analysis.Pass) {
+	for _, file := range pass.Files {
+		qtAlias := importedPkgName(pass, file, quicktestPkgPath)
+		for _, root := range outermostFuncs(file) {
+			planBorrowedCheckers(pass, root, qtAlias)
+		}
+	}
+}
+
+// borrowSite is one subtest closure that reads a checker from outside itself.
+type borrowSite struct {
+	closure subtestClosure
+	name    string
+	obj     types.Object
+	reason  string
+	fixable bool
+}
+
+// planBorrowedCheckers decides every borrowing closure in one outermost
+// function together, then reports them.
+//
+// The decisions are not independent. Giving a closure its own checker shadows
+// the outer name, so the outer declaration loses that use — and when the
+// closures were its only readers, the declaration has to go with them or the
+// function stops compiling. Answering that per closure cannot see the others.
+func planBorrowedCheckers(pass *analysis.Pass, root ast.Node, qtAlias string) {
+	var closures []subtestClosure
+	ast.Inspect(root, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if closure, ok := matchSubtestClosure(pass, call); ok {
+			closures = append(closures, closure)
+		}
+		return true
+	})
+	if len(closures) == 0 {
+		return
+	}
+
+	sites := borrowSites(pass, root, closures, qtAlias)
+	if len(sites) == 0 {
+		return
+	}
+
+	// A declaration whose every reader is a closure being fixed goes with
+	// them. wholeLineSpan declines a declaration sharing its line with
+	// anything else, and the sites that depended on it lose their fix.
+	declEdits := make(map[types.Object][]analysis.TextEdit)
+	for obj := range borrowedObjects(sites) {
+		if survivingBorrowUses(pass, root, obj, sites) > 0 {
+			continue
+		}
+		edits, ok := declRemovalEdits(pass, root, obj)
+		if !ok {
+			for _, s := range sites {
+				if s.obj == obj {
+					s.fixable = false
+					s.reason = "; no fix: the checker's declaration shares its line, so removing it would take that with it"
+				}
+			}
+			continue
+		}
+		declEdits[obj] = edits
+	}
+
+	for _, s := range sites {
+		diag := analysis.Diagnostic{
+			Pos:     s.closure.lit.Type.Pos(),
+			End:     s.closure.lit.Type.End(),
+			Message: "qtlint: this subtest asserts through a *qt.C built from the test around it, so a failure names that test instead" + s.reason,
+		}
+		if s.fixable {
+			edits := []analysis.TextEdit{prependStmtEdit(pass, s.closure.lit.Body,
+				fmt.Sprintf("%s := %s.New(%s)", s.name, qtAlias, s.closure.handle))}
+			diag.SuggestedFixes = []analysis.SuggestedFix{{
+				Message:   "Give the subtest its own qt.New",
+				TextEdits: append(edits, declEdits[s.obj]...),
+			}}
+		}
+		pass.Report(diag)
+	}
+}
+
+// borrowSites attributes every borrowed read to the innermost subtest closure
+// that contains it.
+//
+// Attribution has to be innermost-wins, and the shape that shows why is a
+// subtest whose only assertion sits inside a nested subtest. Reading the outer
+// closure's body finds that assertion too, so charging the borrow to both
+// closures inserts a checker into the outer one that nothing then reads —
+// which does not compile. The innermost subtest is also the one whose failure
+// attribution is actually wrong, so it is the one that needs its own checker.
+func borrowSites(pass *analysis.Pass, root ast.Node, closures []subtestClosure, qtAlias string) []*borrowSite {
+	type key struct {
+		lit *ast.FuncLit
+		obj types.Object
+	}
+	seen := make(map[key]string)
+
+	ast.Inspect(root, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		// A variable, not a type name: the C in *qt.C is an identifier whose
+		// object is the type itself, and reading it is a type reference rather
+		// than an assertion through a checker.
+		v, ok := pass.TypesInfo.Uses[ident].(*types.Var)
+		if !ok || !isQuicktestCType(v.Type()) {
+			return true
+		}
+		obj := types.Object(v)
+		// A package-level checker is not a parent's checker, and shadowing one
+		// would change what the test asserts through rather than which test it
+		// reports against.
+		if obj.Parent() == pass.Pkg.Scope() {
+			return true
+		}
+		lit := innermostClosureAt(closures, ident.Pos())
+		if lit == nil {
+			return true
+		}
+		// A checker the closure declares itself is the conforming shape,
+		// however it spells the name.
+		if declaredWithin(lit, obj) {
+			return true
+		}
+		seen[key{lit: lit, obj: obj}] = ident.Name
+		return true
+	})
+
+	byLit := make(map[*ast.FuncLit]subtestClosure)
+	for _, closure := range closures {
+		byLit[closure.lit] = closure
+	}
+
+	counts := make(map[*ast.FuncLit]int)
+	for k := range seen {
+		counts[k.lit]++
+	}
+
+	sites := make([]*borrowSite, 0, len(seen))
+	for k, name := range seen {
+		closure := byLit[k.lit]
+		reason := ""
+		switch {
+		case closure.handle == "":
+			reason = "; no fix: the closure's *testing.T is blank, so there is no handle to build a checker from"
+		case qtAlias == "":
+			reason = "; no fix: this file does not import quicktest under a name the inserted qt.New could use"
+		case !packageQualifies(pass, qtAlias, quicktestPkgPath, closure.lit.Body.Lbrace):
+			reason = "; no fix: the quicktest qualifier does not mean quicktest where the qt.New would go"
+		case counts[k.lit] > 1:
+			reason = "; no fix: the closure reads more than one checker from outside itself"
+		}
+		sites = append(sites, &borrowSite{
+			closure: closure,
+			name:    name,
+			obj:     k.obj,
+			reason:  reason,
+			fixable: reason == "",
+		})
+	}
+	sort.Slice(sites, func(i, j int) bool {
+		if sites[i].closure.lit.Pos() != sites[j].closure.lit.Pos() {
+			return sites[i].closure.lit.Pos() < sites[j].closure.lit.Pos()
+		}
+		return sites[i].name < sites[j].name
+	})
+	return sites
+}
+
+// innermostClosureAt returns the closure with the smallest span containing pos.
+func innermostClosureAt(closures []subtestClosure, pos token.Pos) *ast.FuncLit {
+	var best *ast.FuncLit
+	for _, closure := range closures {
+		lit := closure.lit
+		if lit.Pos() > pos || pos >= lit.End() {
+			continue
+		}
+		if best == nil || lit.Pos() > best.Pos() {
+			best = lit
+		}
+	}
+	return best
+}
+
+// declaredWithin reports whether obj is declared inside lit.
+func declaredWithin(lit *ast.FuncLit, obj types.Object) bool {
+	return lit.Pos() <= obj.Pos() && obj.Pos() < lit.End()
+}
+
+// borrowedObjects returns the distinct checkers the fixable sites borrow.
+func borrowedObjects(sites []*borrowSite) map[types.Object]bool {
+	objs := make(map[types.Object]bool)
+	for _, s := range sites {
+		if s.fixable {
+			objs[s.obj] = true
+		}
+	}
+	return objs
+}
+
+// survivingBorrowUses counts the reads of obj that outlive the rewrite: every
+// read outside a closure this plan gives its own checker.
+func survivingBorrowUses(pass *analysis.Pass, root ast.Node, obj types.Object, sites []*borrowSite) int {
+	var shadowed []*ast.FuncLit
+	for _, s := range sites {
+		if s.fixable && s.obj == obj {
+			shadowed = append(shadowed, s.closure.lit)
+		}
+	}
+
+	var count int
+	ast.Inspect(root, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if !ok || pass.TypesInfo.Uses[ident] != obj {
+			return true
+		}
+		for _, lit := range shadowed {
+			if lit.Pos() <= ident.Pos() && ident.Pos() < lit.End() {
+				return true
+			}
+		}
+		count++
+		return true
+	})
+	return count
+}
+
+// declRemovalEdits renders the removal of obj's declaration.
+func declRemovalEdits(pass *analysis.Pass, root ast.Node, obj types.Object) ([]analysis.TextEdit, bool) {
+	var decl ast.Node
+	ast.Inspect(root, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 {
+			return true
+		}
+		ident, ok := assign.Lhs[0].(*ast.Ident)
+		if ok && pass.TypesInfo.Defs[ident] == obj {
+			decl = assign
+		}
+		return true
+	})
+	if decl == nil {
+		return nil, false
+	}
+	start, end, ok := wholeLineSpan(pass, decl)
+	if !ok {
+		return nil, false
+	}
+	return []analysis.TextEdit{{Pos: start, End: end}}, true
+}

--- a/requiretestinghandle.go
+++ b/requiretestinghandle.go
@@ -194,43 +194,46 @@ func reportQtCHelper(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExp
 		Message: qtCHelperMessage,
 	}
 
-	edits, ok := qtCHelperEdits(pass, helper, calls)
-	if ok {
+	edits, reason := qtCHelperEdits(pass, helper, calls)
+	if reason == "" {
 		diag.SuggestedFixes = []analysis.SuggestedFix{{
 			Message:   "Take testing.TB and build the *qt.C from it",
 			TextEdits: edits,
 		}}
 	} else {
-		diag.Message += "; no fix: the qualifiers the rewrite would write do not mean their packages where it would write them"
+		diag.Message += reason
 	}
 	pass.Report(diag)
 }
 
 // qtCHelperEdits renders the declaration change, the qt.New the body needs,
 // and one edit per call site.
-func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr) ([]analysis.TextEdit, bool) {
+func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr) ([]analysis.TextEdit, string) {
 	file := fileHolding(pass, helper.decl.Pos())
 	if file == nil {
-		return nil, false
+		return nil, "; no fix: this rule could not find the file the declaration is in"
 	}
 	testingName := importedPkgName(pass, file, testingPkgPath)
 	qtAlias := importedPkgName(pass, file, quicktestPkgPath)
-	if testingName == "" || qtAlias == "" {
-		return nil, false
+	if testingName == "" {
+		return nil, "; no fix: this file does not import testing under a name the new parameter type could use"
+	}
+	if qtAlias == "" {
+		return nil, "; no fix: this file does not import quicktest under a name the inserted qt.New could use"
 	}
 	// Both qualifiers are written into the declaration's own file, so both
 	// have to mean their packages there. A file can import a path twice.
 	if !packageQualifies(pass, testingName, testingPkgPath, helper.param.Pos()) {
-		return nil, false
+		return nil, "; no fix: the testing qualifier does not mean testing where the new parameter type would go"
 	}
 	if !packageQualifies(pass, qtAlias, quicktestPkgPath, helper.decl.Body.Lbrace) {
-		return nil, false
+		return nil, "; no fix: the quicktest qualifier does not mean quicktest where the qt.New would go"
 	}
 
 	callEdits := make([]analysis.TextEdit, 0, len(calls))
 	for _, call := range calls {
 		if helper.index >= len(call.Args) {
-			return nil, false
+			return nil, "; no fix: a call passes fewer arguments than the signature declares, so this rule cannot say which one is the checker"
 		}
 		arg := call.Args[helper.index]
 		callEdits = append(callEdits, analysis.TextEdit{
@@ -248,7 +251,7 @@ func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr
 			Pos:     helper.param.Pos(),
 			End:     helper.param.End(),
 			NewText: []byte(testingName + ".TB"),
-		}}, callEdits...), true
+		}}, callEdits...), ""
 	}
 
 	// A blank parameter keeps its blank name for the same reason, and has no
@@ -258,7 +261,7 @@ func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr
 			Pos:     helper.param.Pos(),
 			End:     helper.param.End(),
 			NewText: []byte("_ " + testingName + ".TB"),
-		}}, callEdits...), true
+		}}, callEdits...), ""
 	}
 
 	// The handle takes a name of its own rather than reusing the checker's, so
@@ -279,7 +282,7 @@ func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr
 			fmt.Sprintf("%s := %s.New(%s)", helper.name, qtAlias, tbName)))
 	}
 
-	return append(edits, callEdits...), true
+	return append(edits, callEdits...), ""
 }
 
 // usesObject reports whether obj is read anywhere inside root.

--- a/requiretestinghandle.go
+++ b/requiretestinghandle.go
@@ -1,0 +1,345 @@
+package qtlint
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// qtCHelperMessage is the diagnostic every -require-testing-handle report
+// opens with; a withheld report appends why it was withheld.
+const qtCHelperMessage = "qtlint: a test helper takes the test handle, not the checker: use testing.TB and build the *qt.C inside"
+
+// qtCHelper describes a function declaration that takes a *qt.C parameter.
+type qtCHelper struct {
+	// decl is the declaration and param the *qt.C parameter's field.
+	decl  *ast.FuncDecl
+	param *ast.Field
+	// name is the parameter's name and obj the object it declares. A blank or
+	// unnamed parameter has neither.
+	name string
+	obj  types.Object
+	// index is the parameter's position in the signature, counted in
+	// parameters rather than fields, so a call's argument list lines up.
+	index int
+}
+
+// checkRequireTestingHandle reports test helpers that take a *qt.C and
+// suggests taking the test handle instead.
+//
+// A helper that takes the checker is what stops -require-testing-run from
+// converting its callers. That rule cannot see what a helper does with a
+// *qt.C, and what it could do includes (*qt.C).Defer, which panics unless
+// Done() ran — so it reports the call site and withholds the rewrite. The
+// helper is the cause; the c.Run it blocks is the symptom.
+//
+// The rewrite is deliberately to testing.TB rather than to *testing.T. Inside
+// a subtest closure that has not been converted yet there is no *testing.T to
+// pass, but there is c.TB: quicktest's C embeds testing.TB, so the checker
+// yields the handle it was built from. Converting to testing.TB therefore
+// leaves every caller compiling at every point, whether or not its enclosing
+// closure has been converted, and -require-testing-run can then do its half.
+// A *testing.T parameter would force both halves to land in one edit.
+func (*analyzer) checkRequireTestingHandle(pass *analysis.Pass) {
+	helpers := make(map[types.Object]qtCHelper)
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			helper, ok := matchQtCHelper(pass, fn)
+			if !ok {
+				continue
+			}
+			if obj := pass.TypesInfo.Defs[fn.Name]; obj != nil {
+				helpers[obj] = helper
+			}
+		}
+	}
+	if len(helpers) == 0 {
+		return
+	}
+
+	calls, unreachable := callSitesByCallee(pass, helpers)
+	for obj, helper := range helpers {
+		// A function named anywhere other than in a call of it is passed as a
+		// value, and its type is written down somewhere this rule does not
+		// edit: a struct field, a variable, a parameter. Rewriting the
+		// declaration alone would leave that type disagreeing with it, so the
+		// site is reported with no call list and therefore no fix.
+		if unreachable[obj] {
+			pass.Report(analysis.Diagnostic{
+				Pos:     helper.param.Pos(),
+				End:     helper.param.End(),
+				Message: qtCHelperMessage + "; no fix: this function is also used as a value, so its type is written down somewhere this rule does not edit",
+			})
+			continue
+		}
+		reportQtCHelper(pass, helper, calls[obj])
+	}
+}
+
+// matchQtCHelper parses fn into a qtCHelper.
+//
+// A method is skipped: its receiver ties it to a type whose other methods this
+// rule has not looked at, and renaming one parameter of one method is not a
+// change with a defensible boundary. A variadic *qt.C is skipped for the same
+// reason a named function argument to c.Run is: the call sites do not line up
+// one to one, so a rewrite would have to guess.
+func matchQtCHelper(pass *analysis.Pass, fn *ast.FuncDecl) (qtCHelper, bool) {
+	if fn.Recv != nil || fn.Type.Params == nil || fn.Body == nil {
+		return qtCHelper{}, false
+	}
+
+	index := 0
+	for _, field := range fn.Type.Params.List {
+		width := len(field.Names)
+		if width == 0 {
+			width = 1
+		}
+		if _, variadic := field.Type.(*ast.Ellipsis); variadic {
+			index += width
+			continue
+		}
+		if !isQuicktestCType(pass.TypesInfo.TypeOf(field.Type)) {
+			index += width
+			continue
+		}
+		// One field may declare several parameters, and rewriting a
+		// c1, c2 *qt.C field means deciding what each becomes. The shape does
+		// not occur in practice and guessing is worse than declining.
+		if width != 1 {
+			return qtCHelper{}, false
+		}
+		helper := qtCHelper{decl: fn, param: field, index: index}
+		if len(field.Names) == 1 && field.Names[0].Name != "_" {
+			helper.name = field.Names[0].Name
+			helper.obj = pass.TypesInfo.Defs[field.Names[0]]
+		}
+		return helper, true
+	}
+	return qtCHelper{}, false
+}
+
+// callSitesByCallee groups every call to one of helpers by the function it
+// calls.
+//
+// A call reached through anything other than the function's own name — a
+// value assigned to a variable, a method expression — is not collected, and
+// its callee is dropped from the result entirely. Rewriting a declaration
+// whose callers this rule cannot enumerate is how a package stops compiling.
+func callSitesByCallee(pass *analysis.Pass, helpers map[types.Object]qtCHelper) (map[types.Object][]*ast.CallExpr, map[types.Object]bool) {
+	calls := make(map[types.Object][]*ast.CallExpr)
+	unreachable := make(map[types.Object]bool)
+
+	for _, file := range pass.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			ident, ok := n.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			obj := pass.TypesInfo.Uses[ident]
+			if obj == nil {
+				return true
+			}
+			if _, ok := helpers[obj]; !ok {
+				return true
+			}
+			call, direct := directCallOf(file, ident)
+			if !direct {
+				// The function is named somewhere that is not a call of it.
+				unreachable[obj] = true
+				return true
+			}
+			calls[obj] = append(calls[obj], call)
+			return true
+		})
+	}
+
+	for obj := range unreachable {
+		delete(calls, obj)
+	}
+	return calls, unreachable
+}
+
+// directCallOf reports the call whose callee is ident, and false when ident is
+// used as anything else.
+func directCallOf(file *ast.File, ident *ast.Ident) (*ast.CallExpr, bool) {
+	var found *ast.CallExpr
+	direct := false
+	inspectWithParent(file, func(n, parent ast.Node) {
+		if n != ast.Node(ident) {
+			return
+		}
+		call, ok := parent.(*ast.CallExpr)
+		if ok && stripParens(call.Fun) == ast.Expr(ident) {
+			found, direct = call, true
+		}
+	})
+	return found, direct
+}
+
+// reportQtCHelper reports one helper and renders the rewrite of its
+// declaration together with every call site.
+func reportQtCHelper(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr) {
+	diag := analysis.Diagnostic{
+		Pos:     helper.param.Pos(),
+		End:     helper.param.End(),
+		Message: qtCHelperMessage,
+	}
+
+	edits, ok := qtCHelperEdits(pass, helper, calls)
+	if ok {
+		diag.SuggestedFixes = []analysis.SuggestedFix{{
+			Message:   "Take testing.TB and build the *qt.C from it",
+			TextEdits: edits,
+		}}
+	} else {
+		diag.Message += "; no fix: the qualifiers the rewrite would write do not mean their packages where it would write them"
+	}
+	pass.Report(diag)
+}
+
+// qtCHelperEdits renders the declaration change, the qt.New the body needs,
+// and one edit per call site.
+func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr) ([]analysis.TextEdit, bool) {
+	file := fileHolding(pass, helper.decl.Pos())
+	if file == nil {
+		return nil, false
+	}
+	testingName := importedPkgName(pass, file, testingPkgPath)
+	qtAlias := importedPkgName(pass, file, quicktestPkgPath)
+	if testingName == "" || qtAlias == "" {
+		return nil, false
+	}
+	// Both qualifiers are written into the declaration's own file, so both
+	// have to mean their packages there. A file can import a path twice.
+	if !packageQualifies(pass, testingName, testingPkgPath, helper.param.Pos()) {
+		return nil, false
+	}
+	if !packageQualifies(pass, qtAlias, quicktestPkgPath, helper.decl.Body.Lbrace) {
+		return nil, false
+	}
+
+	callEdits := make([]analysis.TextEdit, 0, len(calls))
+	for _, call := range calls {
+		if helper.index >= len(call.Args) {
+			return nil, false
+		}
+		arg := call.Args[helper.index]
+		callEdits = append(callEdits, analysis.TextEdit{
+			Pos:     arg.Pos(),
+			End:     arg.End(),
+			NewText: []byte(handleExprText(pass, arg)),
+		})
+	}
+
+	// Go requires a signature to name every parameter or none of them, so an
+	// unnamed *qt.C stays unnamed: writing a name into one field of an
+	// otherwise unnamed list produces "missing parameter type".
+	if len(helper.param.Names) == 0 {
+		return append([]analysis.TextEdit{{
+			Pos:     helper.param.Pos(),
+			End:     helper.param.End(),
+			NewText: []byte(testingName + ".TB"),
+		}}, callEdits...), true
+	}
+
+	// A blank parameter keeps its blank name for the same reason, and has no
+	// body use to satisfy.
+	if helper.name == "" {
+		return append([]analysis.TextEdit{{
+			Pos:     helper.param.Pos(),
+			End:     helper.param.End(),
+			NewText: []byte("_ " + testingName + ".TB"),
+		}}, callEdits...), true
+	}
+
+	// The handle takes a name of its own rather than reusing the checker's, so
+	// the qt.New the body gains can still be spelled c := qt.New(tb) and every
+	// existing use of c in the body keeps meaning the checker.
+	tbName := freeName("tb", takenNamesInFunc(helper.decl))
+	edits := []analysis.TextEdit{{
+		Pos:     helper.param.Pos(),
+		End:     helper.param.End(),
+		NewText: []byte(fmt.Sprintf("%s %s.TB", tbName, testingName)),
+	}}
+
+	// A parameter the body never reads needs no checker built for it, and
+	// building one anyway declares a variable nothing uses. An unused
+	// parameter is legal; an unused local is not.
+	if usesObject(pass, helper.decl.Body, helper.obj) {
+		edits = append(edits, prependStmtEdit(pass, helper.decl.Body,
+			fmt.Sprintf("%s := %s.New(%s)", helper.name, qtAlias, tbName)))
+	}
+
+	return append(edits, callEdits...), true
+}
+
+// usesObject reports whether obj is read anywhere inside root.
+func usesObject(pass *analysis.Pass, root ast.Node, obj types.Object) bool {
+	if obj == nil {
+		return false
+	}
+	used := false
+	ast.Inspect(root, func(n ast.Node) bool {
+		ident, ok := n.(*ast.Ident)
+		if ok && pass.TypesInfo.Uses[ident] == obj {
+			used = true
+		}
+		return !used
+	})
+	return used
+}
+
+// handleExprText renders the argument a converted call site passes.
+//
+// A *qt.C argument becomes c.TB: C embeds testing.TB, so the checker yields
+// the handle it was built from, and the call compiles whether or not the
+// closure around it has been converted yet. An argument that is already a
+// testing.TB is passed through.
+func handleExprText(pass *analysis.Pass, arg ast.Expr) string {
+	text := exprText(pass, arg)
+	if isQuicktestCType(pass.TypesInfo.TypeOf(arg)) {
+		return text + ".TB"
+	}
+	return text
+}
+
+// fileHolding returns the parsed file that contains pos.
+func fileHolding(pass *analysis.Pass, pos token.Pos) *ast.File {
+	for _, file := range pass.Files {
+		if file.Pos() <= pos && pos < file.End() {
+			return file
+		}
+	}
+	return nil
+}
+
+// exprText renders expr back to source.
+func exprText(pass *analysis.Pass, expr ast.Expr) string {
+	var buf bytes.Buffer
+	if err := format.Node(&buf, pass.Fset, expr); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+// takenNamesInFunc returns every name declared or used anywhere in fn, so a
+// name chosen clear of it cannot shadow one the body relies on.
+func takenNamesInFunc(fn *ast.FuncDecl) map[string]bool {
+	taken := make(map[string]bool)
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok {
+			taken[ident.Name] = true
+		}
+		return true
+	})
+	return taken
+}

--- a/requiretestinghandle.go
+++ b/requiretestinghandle.go
@@ -15,10 +15,19 @@ import (
 // opens with; a withheld report appends why it was withheld.
 const qtCHelperMessage = "qtlint: a test helper takes the test handle, not the checker: use testing.TB and build the *qt.C inside"
 
-// qtCHelper describes a function declaration that takes a *qt.C parameter.
+// qtCHelper describes a function that takes a *qt.C parameter, whether it is
+// declared at package level or bound to a variable inside a test.
+//
+// Both shapes are the same defect and the same repair. A test that builds its
+// fixtures with a local closure taking the checker blocks -require-testing-run
+// exactly as a package-level helper does, and leaving the local one out would
+// mean the rule cleared a repository down to the shape it could not see.
 type qtCHelper struct {
-	// decl is the declaration and param the *qt.C parameter's field.
+	// body is the function's body and sig its signature. decl is set only for
+	// a package-level declaration; a local closure has none.
 	decl  *ast.FuncDecl
+	body  *ast.BlockStmt
+	sig   *ast.FuncType
 	param *ast.Field
 	// name is the parameter's name and obj the object it declares. A blank or
 	// unnamed parameter has neither.
@@ -46,33 +55,13 @@ type qtCHelper struct {
 // closure has been converted, and -require-testing-run can then do its half.
 // A *testing.T parameter would force both halves to land in one edit.
 func (*analyzer) checkRequireTestingHandle(pass *analysis.Pass) {
-	helpers := make(map[types.Object]qtCHelper)
-	for _, file := range pass.Files {
-		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok {
-				continue
-			}
-			helper, ok := matchQtCHelper(pass, fn)
-			if !ok {
-				continue
-			}
-			if obj := pass.TypesInfo.Defs[fn.Name]; obj != nil {
-				helpers[obj] = helper
-			}
-		}
-	}
+	helpers := collectQtCHelpers(pass)
 	if len(helpers) == 0 {
 		return
 	}
 
 	calls, unreachable := callSitesByCallee(pass, helpers)
 	for obj, helper := range helpers {
-		// A function named anywhere other than in a call of it is passed as a
-		// value, and its type is written down somewhere this rule does not
-		// edit: a struct field, a variable, a parameter. Rewriting the
-		// declaration alone would leave that type disagreeing with it, so the
-		// site is reported with no call list and therefore no fix.
 		if unreachable[obj] {
 			pass.Report(analysis.Diagnostic{
 				Pos:     helper.param.Pos(),
@@ -85,6 +74,63 @@ func (*analyzer) checkRequireTestingHandle(pass *analysis.Pass) {
 	}
 }
 
+// collectQtCHelpers finds every function in pass that takes a *qt.C, in both
+// shapes it occurs in: a package-level declaration and a closure bound to a
+// variable inside a test.
+func collectQtCHelpers(pass *analysis.Pass) map[types.Object]qtCHelper {
+	helpers := make(map[types.Object]qtCHelper)
+	for _, file := range pass.Files {
+		collectDeclaredHelpers(pass, file, helpers)
+		collectBoundHelpers(pass, file, helpers)
+	}
+	return helpers
+}
+
+// collectDeclaredHelpers gathers the package-level declarations.
+func collectDeclaredHelpers(pass *analysis.Pass, file *ast.File, into map[types.Object]qtCHelper) {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		helper, ok := matchQtCHelper(pass, fn)
+		if !ok {
+			continue
+		}
+		if obj := pass.TypesInfo.Defs[fn.Name]; obj != nil {
+			into[obj] = helper
+		}
+	}
+}
+
+// collectBoundHelpers gathers the closures bound to a variable.
+//
+// A closure bound to a name is the same defect wearing a local one:
+// fixture := func(c *qt.C) … blocks -require-testing-run exactly as a
+// package-level helper does, and leaving it out would mean the rule cleared a
+// repository down to the shape it could not see.
+func collectBoundHelpers(pass *analysis.Pass, file *ast.File, into map[types.Object]qtCHelper) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+			return true
+		}
+		lit, litOK := assign.Rhs[0].(*ast.FuncLit)
+		ident, identOK := assign.Lhs[0].(*ast.Ident)
+		if !litOK || !identOK {
+			return true
+		}
+		obj := pass.TypesInfo.Defs[ident]
+		if obj == nil {
+			return true
+		}
+		if helper, ok := matchQtCLiteral(pass, lit); ok {
+			into[obj] = helper
+		}
+		return true
+	})
+}
+
 // matchQtCHelper parses fn into a qtCHelper.
 //
 // A method is skipped: its receiver ties it to a type whose other methods this
@@ -93,12 +139,30 @@ func (*analyzer) checkRequireTestingHandle(pass *analysis.Pass) {
 // reason a named function argument to c.Run is: the call sites do not line up
 // one to one, so a rewrite would have to guess.
 func matchQtCHelper(pass *analysis.Pass, fn *ast.FuncDecl) (qtCHelper, bool) {
-	if fn.Recv != nil || fn.Type.Params == nil || fn.Body == nil {
+	if fn.Recv != nil {
+		return qtCHelper{}, false
+	}
+	helper, ok := matchQtCSignature(pass, fn.Type, fn.Body)
+	if !ok {
+		return qtCHelper{}, false
+	}
+	helper.decl = fn
+	return helper, true
+}
+
+// matchQtCLiteral parses a function literal bound to a variable.
+func matchQtCLiteral(pass *analysis.Pass, lit *ast.FuncLit) (qtCHelper, bool) {
+	return matchQtCSignature(pass, lit.Type, lit.Body)
+}
+
+// matchQtCSignature finds the sole *qt.C parameter in a signature.
+func matchQtCSignature(pass *analysis.Pass, sig *ast.FuncType, body *ast.BlockStmt) (qtCHelper, bool) {
+	if sig.Params == nil || body == nil {
 		return qtCHelper{}, false
 	}
 
 	index := 0
-	for _, field := range fn.Type.Params.List {
+	for _, field := range sig.Params.List {
 		width := len(field.Names)
 		if width == 0 {
 			width = 1
@@ -117,7 +181,7 @@ func matchQtCHelper(pass *analysis.Pass, fn *ast.FuncDecl) (qtCHelper, bool) {
 		if width != 1 {
 			return qtCHelper{}, false
 		}
-		helper := qtCHelper{decl: fn, param: field, index: index}
+		helper := qtCHelper{body: body, sig: sig, param: field, index: index}
 		if len(field.Names) == 1 && field.Names[0].Name != "_" {
 			helper.name = field.Names[0].Name
 			helper.obj = pass.TypesInfo.Defs[field.Names[0]]
@@ -209,7 +273,7 @@ func reportQtCHelper(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExp
 // qtCHelperEdits renders the declaration change, the qt.New the body needs,
 // and one edit per call site.
 func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr) ([]analysis.TextEdit, string) {
-	file := fileHolding(pass, helper.decl.Pos())
+	file := fileHolding(pass, helper.param.Pos())
 	if file == nil {
 		return nil, "; no fix: this rule could not find the file the declaration is in"
 	}
@@ -226,7 +290,7 @@ func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr
 	if !packageQualifies(pass, testingName, testingPkgPath, helper.param.Pos()) {
 		return nil, "; no fix: the testing qualifier does not mean testing where the new parameter type would go"
 	}
-	if !packageQualifies(pass, qtAlias, quicktestPkgPath, helper.decl.Body.Lbrace) {
+	if !packageQualifies(pass, qtAlias, quicktestPkgPath, helper.body.Lbrace) {
 		return nil, "; no fix: the quicktest qualifier does not mean quicktest where the qt.New would go"
 	}
 
@@ -267,7 +331,7 @@ func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr
 	// The handle takes a name of its own rather than reusing the checker's, so
 	// the qt.New the body gains can still be spelled c := qt.New(tb) and every
 	// existing use of c in the body keeps meaning the checker.
-	tbName := freeName("tb", takenNamesInFunc(helper.decl))
+	tbName := freeName("tb", takenNamesInFunc(helper.sig, helper.body))
 	edits := []analysis.TextEdit{{
 		Pos:     helper.param.Pos(),
 		End:     helper.param.End(),
@@ -277,8 +341,8 @@ func qtCHelperEdits(pass *analysis.Pass, helper qtCHelper, calls []*ast.CallExpr
 	// A parameter the body never reads needs no checker built for it, and
 	// building one anyway declares a variable nothing uses. An unused
 	// parameter is legal; an unused local is not.
-	if usesObject(pass, helper.decl.Body, helper.obj) {
-		edits = append(edits, prependStmtEdit(pass, helper.decl.Body,
+	if usesObject(pass, helper.body, helper.obj) {
+		edits = append(edits, prependStmtEdit(pass, helper.body,
 			fmt.Sprintf("%s := %s.New(%s)", helper.name, qtAlias, tbName)))
 	}
 
@@ -336,13 +400,15 @@ func exprText(pass *analysis.Pass, expr ast.Expr) string {
 
 // takenNamesInFunc returns every name declared or used anywhere in fn, so a
 // name chosen clear of it cannot shadow one the body relies on.
-func takenNamesInFunc(fn *ast.FuncDecl) map[string]bool {
+func takenNamesInFunc(nodes ...ast.Node) map[string]bool {
 	taken := make(map[string]bool)
-	ast.Inspect(fn, func(n ast.Node) bool {
-		if ident, ok := n.(*ast.Ident); ok {
-			taken[ident.Name] = true
-		}
-		return true
-	})
+	for _, node := range nodes {
+		ast.Inspect(node, func(n ast.Node) bool {
+			if ident, ok := n.(*ast.Ident); ok {
+				taken[ident.Name] = true
+			}
+			return true
+		})
+	}
 	return taken
 }

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -168,6 +168,13 @@ type runSite struct {
 	// carries edits. A site that is not reported is never fixed.
 	reported bool
 	fixed    bool
+
+	// withheldReason is the clause the diagnostic appends when the site is
+	// reported without a fix, naming what withheld it. A reported site with no
+	// fix and no reason would leave the reader to work out which of a
+	// closure's indirections the rule could not see through, which is the one
+	// question the tool is in a position to answer.
+	withheldReason string
 }
 
 // runPlan holds the -require-testing-run decisions for every c.Run site
@@ -329,10 +336,16 @@ func (p *runPlan) resolve(pass *analysis.Pass, onlyStableFixes bool) {
 		}
 		reach := closureCReach(pass, s.run)
 		withheld := reach.deferred || (onlyStableFixes && reach.testScoped)
+		if withheld {
+			s.withheldReason = reach.withholdReason(onlyStableFixes)
+		}
 		if s.outer != nil {
 			s.recvText = s.outer.tName
 			s.reported = s.outer.reported
 			s.fixed = s.outer.fixed && !withheld
+			if !s.fixed && s.withheldReason == "" {
+				s.withheldReason = s.outer.withheldReason
+			}
 			continue
 		}
 		name, ok := targetFromQtNew(pass, p.origins, s.run)
@@ -417,7 +430,7 @@ func (p *runPlan) report(pass *analysis.Pass) {
 		diag := analysis.Diagnostic{
 			Pos:     s.call.Fun.Pos(),
 			End:     s.call.Fun.End(),
-			Message: "qtlint: use t.Run with a per-subtest qt.New instead of c.Run",
+			Message: "qtlint: use t.Run with a per-subtest qt.New instead of c.Run" + s.withheldReason,
 		}
 		if edits, ok := p.edits(pass, s); s.fixed && ok {
 			diag.SuggestedFixes = []analysis.SuggestedFix{{
@@ -540,6 +553,35 @@ type cReach struct {
 	// scope is the test rather than the assertion.
 	deferred   bool
 	testScoped bool
+
+	// escape names the first use the analysis could not follow, and method the
+	// first spelled-out method that decided the reach. Exactly one is usually
+	// set, and both may be empty when nothing withholds the fix.
+	//
+	// They exist so a withheld fix can say what withheld it. Without them the
+	// diagnostic reads the same whether the fix was applied or not, and a
+	// reader has to work out which of a closure's several indirections was the
+	// one the rule could not see through.
+	escape string
+	method string
+}
+
+// withholdReason renders why a fix was withheld, as a clause a diagnostic can
+// append to its message. It returns the empty string when nothing withholds.
+func (r cReach) withholdReason(onlyStableFixes bool) string {
+	switch {
+	case r.escape != "":
+		return "; no fix: the *qt.C is handed to " + r.escape +
+			", so what it can reach includes (*qt.C).Defer, which panics unless Done() ran" +
+			" — give that function a *testing.T instead and this converts"
+	case r.deferred:
+		return "; no fix: the closure calls c." + r.method +
+			", and a bare qt.New(t) supplies no Done() the way C.Run does"
+	case onlyStableFixes && r.testScoped:
+		return "; no fix under -only-stable-fixes: the closure calls c." + r.method +
+			", which binds to whichever test the *qt.C came from"
+	}
+	return ""
 }
 
 // closureCReach works out what run's closure can do to its own *qt.C.
@@ -570,8 +612,14 @@ func closureCReach(pass *analysis.Pass, run qtCRun) cReach {
 			switch {
 			case deferredCMethods[sel.Sel.Name]:
 				reach.deferred = true
+				if reach.method == "" {
+					reach.method = sel.Sel.Name
+				}
 			case testScopedCMethods[sel.Sel.Name]:
 				reach.testScoped = true
+				if reach.method == "" {
+					reach.method = sel.Sel.Name
+				}
 			}
 			return
 		}
@@ -584,8 +632,45 @@ func closureCReach(pass *analysis.Pass, run qtCRun) cReach {
 		// withholding a fix that was not needed costs only a fix.
 		reach.deferred = true
 		reach.testScoped = true
+		if reach.escape == "" {
+			reach.escape = escapeDescription(parent)
+		}
 	})
 	return reach
+}
+
+// escapeDescription names the construct a *qt.C escaped into, in the words a
+// reader would use for it. The name is what makes a withheld fix actionable:
+// "handed to helper(...)" points at the function whose signature to change,
+// where "cannot fix" points at nothing.
+func escapeDescription(parent ast.Node) string {
+	switch p := parent.(type) {
+	case *ast.CallExpr:
+		if name := calleeName(p.Fun); name != "" {
+			return name + "(...)"
+		}
+		return "a function call"
+	case *ast.KeyValueExpr, *ast.CompositeLit:
+		return "a composite literal"
+	case *ast.ReturnStmt:
+		return "the function's result"
+	}
+	return "an expression this rule cannot follow"
+}
+
+// calleeName renders the called function's name for an escape description,
+// including the receiver or package qualifier when there is one.
+func calleeName(fun ast.Expr) string {
+	switch f := stripParens(fun).(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		if x, ok := stripParens(f.X).(*ast.Ident); ok {
+			return x.Name + "." + f.Sel.Name
+		}
+		return f.Sel.Name
+	}
+	return ""
 }
 
 // heldQtCObjects returns cObj together with every variable inside lit that a

--- a/testdata/src/subtestchecker/subtestchecker.go
+++ b/testdata/src/subtestchecker/subtestchecker.go
@@ -1,0 +1,45 @@
+package subtestchecker
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The defect: the subtest asserts through the checker of the test around it,
+// so the failure names that test and an Assert stops it rather than the
+// subtest. It compiles and passes, which is why it needs a rule.
+func TestBorrows(t *testing.T) {
+	c := qt.New(t)
+	t.Run("sub", func(t *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead"
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Conforming: the subtest builds its own.
+func TestOwn(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Conforming control. Reading the enclosing test's handle is not a violation:
+// a subtest may legitimately want the parent's name. Only the checker decides
+// which test an assertion reports against.
+func TestReadsParentHandle(t *testing.T) {
+	t.Run("sub", func(t2 *testing.T) {
+		c := qt.New(t2)
+		c.Assert(t.Name(), qt.Not(qt.Equals), "")
+	})
+}
+
+// A blank handle leaves nothing to build a checker from, so the site is
+// reported without a fix rather than rewritten into something that does not
+// compile.
+func TestBlankHandle(t *testing.T) {
+	c := qt.New(t)
+	t.Run("sub", func(_ *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead; no fix: the closure's \\*testing.T is blank, so there is no handle to build a checker from"
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/subtestcheckerfix/subtestcheckerfix.go
+++ b/testdata/src/subtestcheckerfix/subtestcheckerfix.go
@@ -43,3 +43,12 @@ func TestBlankHandle(t *testing.T) {
 		c.Assert(1, qt.Equals, 1)
 	})
 }
+
+// A checker declared with var rather than :=. Both spellings have to be
+// removable, or a var-declared checker reports a cause that is not its own.
+func TestVarDeclaredChecker(t *testing.T) {
+	var c = qt.New(t)
+	t.Run("sub", func(t *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead"
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/subtestcheckerfix/subtestcheckerfix.go
+++ b/testdata/src/subtestcheckerfix/subtestcheckerfix.go
@@ -1,0 +1,45 @@
+package subtestcheckerfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The defect: the subtest asserts through the checker of the test around it,
+// so the failure names that test and an Assert stops it rather than the
+// subtest. It compiles and passes, which is why it needs a rule.
+func TestBorrows(t *testing.T) {
+	c := qt.New(t)
+	t.Run("sub", func(t *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead"
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Conforming: the subtest builds its own.
+func TestOwn(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Conforming control. Reading the enclosing test's handle is not a violation:
+// a subtest may legitimately want the parent's name. Only the checker decides
+// which test an assertion reports against.
+func TestReadsParentHandle(t *testing.T) {
+	t.Run("sub", func(t2 *testing.T) {
+		c := qt.New(t2)
+		c.Assert(t.Name(), qt.Not(qt.Equals), "")
+	})
+}
+
+// A blank handle leaves nothing to build a checker from, so the site is
+// reported without a fix rather than rewritten into something that does not
+// compile.
+func TestBlankHandle(t *testing.T) {
+	c := qt.New(t)
+	t.Run("sub", func(_ *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead; no fix: the closure's \\*testing.T is blank, so there is no handle to build a checker from"
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/subtestcheckerfix/subtestcheckerfix.go.golden
+++ b/testdata/src/subtestcheckerfix/subtestcheckerfix.go.golden
@@ -1,0 +1,45 @@
+package subtestcheckerfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The defect: the subtest asserts through the checker of the test around it,
+// so the failure names that test and an Assert stops it rather than the
+// subtest. It compiles and passes, which is why it needs a rule.
+func TestBorrows(t *testing.T) {
+	t.Run("sub", func(t *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Conforming: the subtest builds its own.
+func TestOwn(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}
+
+// Conforming control. Reading the enclosing test's handle is not a violation:
+// a subtest may legitimately want the parent's name. Only the checker decides
+// which test an assertion reports against.
+func TestReadsParentHandle(t *testing.T) {
+	t.Run("sub", func(t2 *testing.T) {
+		c := qt.New(t2)
+		c.Assert(t.Name(), qt.Not(qt.Equals), "")
+	})
+}
+
+// A blank handle leaves nothing to build a checker from, so the site is
+// reported without a fix rather than rewritten into something that does not
+// compile.
+func TestBlankHandle(t *testing.T) {
+	c := qt.New(t)
+	t.Run("sub", func(_ *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead; no fix: the closure's \\*testing.T is blank, so there is no handle to build a checker from"
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/subtestcheckerfix/subtestcheckerfix.go.golden
+++ b/testdata/src/subtestcheckerfix/subtestcheckerfix.go.golden
@@ -43,3 +43,12 @@ func TestBlankHandle(t *testing.T) {
 		c.Assert(1, qt.Equals, 1)
 	})
 }
+
+// A checker declared with var rather than :=. Both spellings have to be
+// removable, or a var-declared checker reports a cause that is not its own.
+func TestVarDeclaredChecker(t *testing.T) {
+	t.Run("sub", func(t *testing.T) { // want "qtlint: this subtest asserts through a \\*qt.C built from the test around it, so a failure names that test instead"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -99,3 +99,24 @@ func TestNestedUnstableOuter(t *testing.T) {
 		})
 	})
 }
+
+// escapeHelper takes the checker, so a closure that calls it hands its *qt.C
+// somewhere this rule cannot follow.
+func escapeHelper(c *qt.C) string { return c.TempDir() }
+
+// A withheld site says what withheld it. The clause names the construct the
+// *qt.C escaped into, because that is the one question the tool can answer and
+// the reader cannot: which of a closure's indirections was the opaque one, and
+// therefore whose signature to change.
+func TestWithholdingNamesItsCause(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("escape", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to escapeHelper\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
+		c.Assert(escapeHelper(c), qt.Not(qt.Equals), "")
+	})
+
+	c.Run("deferred", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		c.Defer(func() {})
+		c.Done()
+	})
+}

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -120,3 +120,15 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Done()
 	})
 }
+
+// The -only-stable-fixes branch of the explanation. A test-scoped method is
+// not a correctness hazard the way Defer is, so the clause names the flag that
+// withheld the fix rather than a panic that would not happen.
+func TestOnlyStableFixesNamesTheFlag(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("cleanup", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure calls c.Cleanup, which binds to whichever test the \\*qt.C came from"
+		c.Cleanup(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -122,3 +122,15 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Done()
 	})
 }
+
+// The -only-stable-fixes branch of the explanation. A test-scoped method is
+// not a correctness hazard the way Defer is, so the clause names the flag that
+// withheld the fix rather than a panic that would not happen.
+func TestOnlyStableFixesNamesTheFlag(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("cleanup", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure calls c.Cleanup, which binds to whichever test the \\*qt.C came from"
+		c.Cleanup(func() {})
+		c.Assert(1, qt.Equals, 1)
+	})
+}

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -101,3 +101,24 @@ func TestNestedUnstableOuter(t *testing.T) {
 	})
 }
 
+
+// escapeHelper takes the checker, so a closure that calls it hands its *qt.C
+// somewhere this rule cannot follow.
+func escapeHelper(c *qt.C) string { return c.TempDir() }
+
+// A withheld site says what withheld it. The clause names the construct the
+// *qt.C escaped into, because that is the one question the tool can answer and
+// the reader cannot: which of a closure's indirections was the opaque one, and
+// therefore whose signature to change.
+func TestWithholdingNamesItsCause(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("escape", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to escapeHelper\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
+		c.Assert(escapeHelper(c), qt.Not(qt.Equals), "")
+	})
+
+	c.Run("deferred", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		c.Defer(func() {})
+		c.Done()
+	})
+}


### PR DESCRIPTION
Adds `-require-subtest-checker` and `-require-testing-handle`, and makes a withheld `-require-testing-run` fix say what withheld it.

An assertion reports against whichever test its checker was built from. The existing pair enforces that for two shapes; these close the rest.

## `-require-subtest-checker` — closes #66

```go
func TestX(t *testing.T) {
	c := qt.New(t)
	t.Run("sub", func(t *testing.T) {
		c.Assert(got, qt.Equals, want)   // c belongs to TestX
	})
}
```

Compiles, passes, and names the wrong test on failure — an `Assert` stops the parent rather than the subtest. Neither existing rule sees it: there is no `c.Run` to rewrite and the assertion already goes through a receiver.

Measured on a repository of ~600 test files: **37 real sites**.

## `-require-testing-handle`

A helper taking a `*qt.C` is what stops `-require-testing-run` from converting its callers, because the analyzer cannot see what a helper does with a checker and what it could do includes `(*qt.C).Defer`.

The rewrite is to `testing.TB`, not `*testing.T`. Inside a subtest closure that has not been converted yet there is no `*testing.T` to pass, but there is `c.TB` — `C` embeds `testing.TB`. So every intermediate state compiles and the two conversions can land separately. On the same repository the chain took withheld sites from **266 to 70**, with 543 files converted, and the remaining 70 each name their cause.

## Withheld fixes now explain themselves

```
before: qtlint: use t.Run with a per-subtest qt.New instead of c.Run
after:  ...; no fix: the *qt.C is handed to writeIntegrityFixture(...), so what it can reach
        includes (*qt.C).Defer, which panics unless Done() ran — give that function a
        *testing.T instead and this converts
```

That turned "read 266 closures" into one `grep`, and the 88 functions to convert fell out of it.

## What running it on real code found that fixtures did not

Four defects, each fixed here, each invisible to a fixture suite:

- an **unnamed** parameter cannot be given a name — Go requires all-named or all-unnamed, so `func f(*qt.C, string)` became `missing parameter type`;
- a parameter the body never reads needs no checker built for it, or the inserted declaration is unused;
- a function also used as a **value** has its type written in a struct field the rewrite does not reach;
- a borrowed read belongs to the **innermost** subtest containing it — charging it to every enclosing closure inserts a checker nothing reads.

Both rules plan a whole function before reporting any of it, for the reason `-require-testing-run` already does: shadowing an outer checker removes the last read of its declaration, and deciding that per site cannot see the siblings.

## Coverage

New fixtures for both rules, including the conforming controls — a subtest that builds its own checker, and one that reads the enclosing `t.Name()`, which is **not** a violation. The message fixture is not decorative: against the pre-change source `TestFixes/testingrun_only-stable-fixes` fails naming both new patterns.

Worth recording: `analysistest` matches `// want` as an unanchored regexp, so appending a clause does not break existing fixtures. Every pre-existing fixture stayed green through the message change, which means the new text had zero coverage until its fixture existed.

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 · `go test -race ./... -count=1` 0 · `golangci-lint run ./...` 0.