### PR TITLE
feat: add -require-data-rows, and make every suggested fix stand alone

### DIFF
--- a/qtlint.go
+++ b/qtlint.go
@@ -79,6 +79,10 @@ type analyzer struct {
 	// requireSubtestChecker enables the opt-in house-style rule that requires
 	// a subtest to assert through its own *qt.C.
 	requireSubtestChecker bool
+
+	// requireDataRows enables the opt-in house-style rule that refuses a
+	// table-row function field whose every row holds one assertion.
+	requireDataRows bool
 }
 
 // NewAnalyzer creates a new instance of the qtlint analyzer.
@@ -97,6 +101,8 @@ func NewAnalyzer() *analysis.Analyzer {
 	aa.Flags.BoolVar(&a.requireQtCReceiver, "require-qt-c-receiver", false,
 		"house-style rule, off by default: report qt.Assert(t, ...) and "+
 			"qt.Check(t, ...) and suggest the *qt.C method form")
+	aa.Flags.BoolVar(&a.requireDataRows, "require-data-rows", false,
+		"report a table-row func field whose every row holds one assertion (opt-in)")
 	aa.Flags.BoolVar(&a.requireSubtestChecker, "require-subtest-checker", false,
 		"report a subtest that asserts through the enclosing test's *qt.C (opt-in)")
 	aa.Flags.BoolVar(&a.requireTestingHandle, "require-testing-handle", false,
@@ -201,6 +207,9 @@ func (a *analyzer) runOptInRules(pass *analysis.Pass, insp *inspector.Inspector)
 	}
 	if a.requireSubtestChecker {
 		a.checkRequireSubtestChecker(pass)
+	}
+	if a.requireDataRows {
+		a.checkRequireDataRows(pass)
 	}
 	if a.requireTestingRun {
 		a.checkRequireTestingRun(pass)

--- a/qtlint_fix_test.go
+++ b/qtlint_fix_test.go
@@ -98,6 +98,16 @@ func TestFixes(t *testing.T) {
 	// A subtest asserting through the checker of the test around it. Neither
 	// other rule sees the shape: there is no c.Run to rewrite and the
 	// assertion already goes through a receiver.
+	// Both opt-in rules in one pass, on a receiver they both reach. Each plans
+	// against the same declaration; one would remove it and the other writes a
+	// use of it.
+	t.Run("both rules", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-testing-run")
+		setFlag(t, analyzer, "require-qt-c-receiver")
+		analysistest.RunWithSuggestedFixes(t, testdata, analyzer, "bothrulesfix")
+	})
+
 	t.Run("subtestchecker", func(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		setFlag(t, analyzer, "require-subtest-checker")

--- a/qtlint_test.go
+++ b/qtlint_test.go
@@ -22,6 +22,15 @@ func TestAnalyzer(t *testing.T) {
 		analysistest.Run(t, testdata, analyzer, "a")
 	})
 
+	// A table-row function field whose every row holds one assertion, and the
+	// three shapes that are not it: a row doing two things, a row calling a
+	// helper, and a table of one row.
+	t.Run("data rows", func(t *testing.T) {
+		analyzer := qtlint.NewAnalyzer()
+		setFlag(t, analyzer, "require-data-rows")
+		analysistest.Run(t, testdata, analyzer, "datarows")
+	})
+
 	t.Run("method calls", func(t *testing.T) {
 		analyzer := qtlint.NewAnalyzer()
 		analysistest.Run(t, testdata, analyzer, "b")

--- a/requiredatarows.go
+++ b/requiredatarows.go
@@ -1,0 +1,234 @@
+package qtlint
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// assertionField describes a struct field whose type is a function taking a
+// test handle, together with every closure the table's rows assign to it.
+type assertionField struct {
+	// name is the field's name and field its declaration.
+	name  string
+	field *ast.Field
+	// param is the handle parameter every row's closure asserts through, and
+	// index its position in the signature.
+	param *ast.Field
+	index int
+	// bodies are the row closures, in source order.
+	bodies []*ast.FuncLit
+}
+
+// checkRequireDataRows reports a table-row function field whose every row holds
+// a single assertion, because the field is carrying data as code.
+//
+// A table-driven test that forbids conditionals in its body pushes the varying
+// part into the rows. When the varying part is a value, the row carries a
+// value. When a project reaches for a closure instead, the branch it could not
+// write as an `if` reappears one row at a time, spelled out:
+//
+//	tests := []struct {
+//		name   string
+//		assert func(c *qt.C, err error)
+//	}{
+//		{name: "…", assert: func(c *qt.C, err error) {
+//			c.Assert(err, qt.ErrorMatches, `table "public.users" is declared more than once;.*`)
+//		}},
+//		// fifty more, each three lines carrying one string
+//	}
+//
+// As data that row is `wantErr: "…"` and the table reads as a table.
+//
+// The rule reports only when EVERY row for a field holds exactly one assertion
+// through the handle. A field whose closures differ in shape is doing work no
+// data field can, and reporting it would be telling an author to write worse
+// code. That is the discriminating condition, and it is why the rule counts
+// rows rather than matching a name like `assert`.
+//
+// No fix is suggested. Replacing the field means naming the data it stands for,
+// rewriting every row, and turning the call site into an assertion — three
+// decisions that belong to the author. The diagnostic exists because the shape
+// grows silently: every row is locally reasonable, and only the count shows it.
+func (*analyzer) checkRequireDataRows(pass *analysis.Pass) {
+	for _, file := range pass.Files {
+		for _, root := range outermostFuncs(file) {
+			for _, spec := range structTypesIn(root) {
+				for _, field := range assertionFieldsOf(pass, spec) {
+					collectRowBodies(pass, root, spec, field)
+					reportDataRowField(pass, field)
+				}
+			}
+		}
+	}
+}
+
+// structTypesIn returns every struct type literal under root.
+func structTypesIn(root ast.Node) []*ast.StructType {
+	var out []*ast.StructType
+	ast.Inspect(root, func(n ast.Node) bool {
+		if s, ok := n.(*ast.StructType); ok {
+			out = append(out, s)
+		}
+		return true
+	})
+	return out
+}
+
+// assertionFieldsOf returns the fields of spec whose type is a function taking
+// a test handle.
+func assertionFieldsOf(pass *analysis.Pass, spec *ast.StructType) []*assertionField {
+	if spec.Fields == nil {
+		return nil
+	}
+
+	var out []*assertionField
+	for _, field := range spec.Fields.List {
+		sig, ok := field.Type.(*ast.FuncType)
+		if !ok || len(field.Names) != 1 || sig.Params == nil {
+			continue
+		}
+		param, index, ok := handleParam(pass, sig)
+		if !ok {
+			continue
+		}
+		out = append(out, &assertionField{
+			name:  field.Names[0].Name,
+			field: field,
+			param: param,
+			index: index,
+		})
+	}
+	return out
+}
+
+// handleParam finds the sole *qt.C or testing.TB parameter of a signature.
+func handleParam(pass *analysis.Pass, sig *ast.FuncType) (*ast.Field, int, bool) {
+	index := 0
+	for _, field := range sig.Params.List {
+		width := len(field.Names)
+		if width == 0 {
+			width = 1
+		}
+		typ := pass.TypesInfo.TypeOf(field.Type)
+		if isTestHandleType(typ) {
+			if width != 1 {
+				return nil, 0, false
+			}
+			return field, index, true
+		}
+		index += width
+	}
+	return nil, 0, false
+}
+
+// collectRowBodies gathers the closures the table's rows assign to the field.
+//
+// The rows are found from the declaration NODE rather than from its type. Two
+// anonymous struct types of the same shape are identical to go/types, so
+// matching on the type hands one table the rows of another that happens to
+// declare the same fields — a one-row table then reports on a two-row
+// neighbour's closures, and the same closures can be reported twice at two
+// field positions. Bounding the search to one function narrows that window
+// without closing it.
+//
+// The AST already says which literal belongs to which declaration: the rows
+// are the elements of the composite literal whose type expression IS this
+// struct type node, directly or as the element of a slice or array of it.
+func collectRowBodies(_ *analysis.Pass, root ast.Node, spec *ast.StructType, field *assertionField) {
+	ast.Inspect(root, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok || !litDeclaredBy(lit, spec) {
+			return true
+		}
+		for _, elt := range lit.Elts {
+			collectFieldBody(elt, field)
+			// A slice literal's elements are the rows; a bare struct literal
+			// is one row and its elements are the fields.
+			if row, ok := elt.(*ast.CompositeLit); ok {
+				for _, inner := range row.Elts {
+					collectFieldBody(inner, field)
+				}
+			}
+		}
+		return true
+	})
+}
+
+// litDeclaredBy reports whether lit's rows are values of the struct type
+// written at spec, by node identity rather than by type.
+//
+// The table is written as []struct{…}{…}, so the rows sit in the elements of
+// the outer literal and each element is itself a literal with no type of its
+// own. Both shapes reach here: the outer one carries an array type whose
+// element is spec, and an element carries no type expression at all and is
+// matched through its parent.
+func litDeclaredBy(lit *ast.CompositeLit, spec *ast.StructType) bool {
+	switch typ := lit.Type.(type) {
+	case *ast.StructType:
+		return typ == spec
+	case *ast.ArrayType:
+		inner, ok := typ.Elt.(*ast.StructType)
+		return ok && inner == spec
+	}
+	return false
+}
+
+// reportDataRowField reports the field.
+//
+// Every one of them: a table row carries data, and a checker in a row is a
+// branch the table was supposed to remove. It does not matter how much the
+// closure does. A row whose assertions differ from its neighbours in shape is
+// not a row that has earned a closure — it is a second test wearing the first
+// one's table, and the style guide that forbids the conditional also asks for
+// the happy path and the failure path to be separate tests.
+//
+// So there is no threshold and no row count to reach. Carrying a checker into
+// a row is the defect.
+func reportDataRowField(pass *analysis.Pass, field *assertionField) {
+	pass.Report(analysis.Diagnostic{
+		Pos: field.field.Pos(),
+		End: field.field.End(),
+		Message: "qtlint: a table row carries data, not a checker" +
+			"; give the row the value that varies, or split the table into the tests its rows are asserting differently",
+	})
+}
+
+// isTestHandleType reports whether typ is a way to assert: a *qt.C, a
+// *testing.T, or the testing.TB a checker is built from.
+//
+// The field's NAME is not consulted. A row carrying the means to assert is the
+// defect whatever it is called, and matching a name like "assert" would find
+// the tidy cases and miss the rest.
+func isTestHandleType(typ types.Type) bool {
+	if typ == nil {
+		return false
+	}
+	if isQuicktestCType(typ) || isTestingTPtr(typ) {
+		return true
+	}
+	named, ok := types.Unalias(typ).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == testingPkgPath &&
+		(obj.Name() == "TB" || obj.Name() == "B" || obj.Name() == "F")
+}
+
+// collectFieldBody records elt when it assigns a closure to the field.
+func collectFieldBody(elt ast.Expr, field *assertionField) {
+	kv, ok := elt.(*ast.KeyValueExpr)
+	if !ok {
+		return
+	}
+	key, ok := kv.Key.(*ast.Ident)
+	if !ok || key.Name != field.name {
+		return
+	}
+	if body, ok := kv.Value.(*ast.FuncLit); ok {
+		field.bodies = append(field.bodies, body)
+	}
+}

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -192,6 +192,10 @@ type runPlan struct {
 	root    ast.Node
 	origins map[types.Object]qtCOrigin
 
+	// requireQtCReceiver says the other opt-in rule is enabled in the same
+	// run, so this plan has to account for the uses it will write.
+	requireQtCReceiver bool
+
 	// qtAlias and testingName are the names the file imports the two packages
 	// under. Both are empty when the file does not import one of them under a
 	// name a new reference could use, and the plan is then empty.
@@ -206,9 +210,10 @@ type runPlan struct {
 // which of those receive edits.
 func (a *analyzer) planTestingRun(pass *analysis.Pass, file *ast.File, root ast.Node) *runPlan {
 	plan := &runPlan{
-		root:        root,
-		qtAlias:     importedPkgName(pass, file, quicktestPkgPath),
-		testingName: importedPkgName(pass, file, testingPkgPath),
+		root:               root,
+		requireQtCReceiver: a.requireQtCReceiver,
+		qtAlias:            importedPkgName(pass, file, quicktestPkgPath),
+		testingName:        importedPkgName(pass, file, testingPkgPath),
 	}
 	if plan.qtAlias == "" || plan.testingName == "" {
 		// The rewrite has to name both packages, so there is nothing to plan.
@@ -447,25 +452,46 @@ func (p *runPlan) report(pass *analysis.Pass) {
 // withdrawn every reported site for.
 func (p *runPlan) edits(pass *analysis.Pass, s *runSite) ([]analysis.TextEdit, bool) {
 	// The receiver may have had no other use, in which case its declaration
-	// goes with the rewrite. Siblings sharing the receiver each carry the
-	// same deletion; identical edits collapse when a driver applies them.
+	// goes with the rewrite.
 	edits, ok := p.declEdits(pass, s.run.recvObj)
 	if !ok {
 		return nil, false
 	}
 
-	edits = append(edits,
-		analysis.TextEdit{
+	// Every site sharing this receiver is rewritten by this one fix, not only
+	// the site the diagnostic sits on.
+	//
+	// A SuggestedFix is the unit an editor applies. Carrying the declaration's
+	// deletion in each sibling's fix separately is correct only for a driver
+	// that applies all of them: accept one code action in gopls and the
+	// declaration goes while the siblings that still name it stay, which does
+	// not compile. Making each fix convert the whole group leaves every one of
+	// them self-contained, and the group's fixes are then identical, so a
+	// driver applying all of them collapses the duplicates exactly as before.
+	for _, sibling := range p.sites {
+		if !sibling.fixed || sibling.run.recvObj != s.run.recvObj {
+			continue
+		}
+		edits = append(edits, p.siteEdits(pass, sibling)...)
+	}
+	return edits, true
+}
+
+// siteEdits renders the rewrite of one site, without the declaration removal
+// the whole group shares.
+func (p *runPlan) siteEdits(pass *analysis.Pass, s *runSite) []analysis.TextEdit {
+	edits := []analysis.TextEdit{
+		{
 			Pos:     s.run.sel.X.Pos(),
 			End:     s.run.sel.X.End(),
 			NewText: []byte(s.recvText),
 		},
-		analysis.TextEdit{
+		{
 			Pos:     s.run.param.Pos(),
 			End:     s.run.param.End(),
 			NewText: []byte(newRunParam(s.run, s.tName, p.testingName)),
 		},
-	)
+	}
 
 	// The *qt.C is recreated only if the closure still needs one. A closure
 	// whose only use of it was the receiver of a nested c.Run loses that use
@@ -474,7 +500,7 @@ func (p *runPlan) edits(pass *analysis.Pass, s *runSite) ([]analysis.TextEdit, b
 		edits = append(edits, prependStmtEdit(pass, s.run.lit.Body,
 			fmt.Sprintf("%s := %s.New(%s)", s.run.cName, p.qtAlias, s.tName)))
 	}
-	return edits, true
+	return edits
 }
 
 // declEdits returns the edits that remove obj's declaration when the plan
@@ -484,7 +510,7 @@ func (p *runPlan) edits(pass *analysis.Pass, s *runSite) ([]analysis.TextEdit, b
 // cleanly, because there is then no correct fix.
 func (p *runPlan) declEdits(pass *analysis.Pass, obj types.Object) ([]analysis.TextEdit, bool) {
 	origin, ok := p.origins[obj]
-	if !ok || p.survivingUses(pass, p.root, obj) > 0 {
+	if !ok || p.survivingUses(pass, p.root, obj) > 0 || p.receiverRuleWillUse(pass, obj) {
 		return nil, true
 	}
 	start, end, ok := wholeLineSpan(pass, origin.decl)
@@ -517,6 +543,58 @@ func (p *runPlan) survivingUses(pass *analysis.Pass, root ast.Node, obj types.Ob
 		return true
 	})
 	return count
+}
+
+// receiverRuleWillUse reports whether -require-qt-c-receiver, when it is also
+// enabled, would rewrite a package-level assertion in this function into a use
+// of obj.
+//
+// The two rules plan against the same receiver. This one deletes a declaration
+// whose last use it consumed; the other turns qt.Assert(t, …) into
+// c.Assert(…), which is a use of exactly that declaration. Neither is wrong
+// alone, and applied together on a receiver whose only other use was the
+// c.Run they produce a file that does not compile.
+//
+// So the deletion asks the other rule what it is about to write. The answer is
+// conservative in the safe direction: a declaration kept when nothing ends up
+// using it is a lint finding, and one removed while something does is a build
+// failure.
+func (p *runPlan) receiverRuleWillUse(pass *analysis.Pass, obj types.Object) bool {
+	if !p.requireQtCReceiver {
+		return false
+	}
+	origin, ok := p.origins[obj]
+	if !ok {
+		return false
+	}
+	tIdent, ok := origin.arg.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	tObj := pass.TypesInfo.Uses[tIdent]
+	if tObj == nil {
+		return false
+	}
+
+	found := false
+	ast.Inspect(p.root, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		assertion, ok := matchPackageLevelAssertion(pass, call)
+		if !ok {
+			return true
+		}
+		// Only an assertion the other rule would bind to THIS receiver
+		// matters: it rewrites qt.Assert(t, …) into a use of the *qt.C built
+		// from that same t.
+		if assertion.tObj == tObj {
+			found = true
+		}
+		return !found
+	})
+	return found
 }
 
 // targetFromQtNew returns the name of the *testing.T behind a receiver

--- a/testdata/src/bothrulesfix/bothrulesfix.go
+++ b/testdata/src/bothrulesfix/bothrulesfix.go
@@ -1,0 +1,31 @@
+// Package bothrulesfix pins the rewrites of the two opt-in rules applied in
+// one pass.
+//
+// The order test next door uses its own fixture and keeps the two rules from
+// meeting on one receiver, so the combined FIX path had no coverage: each rule
+// plans against the same declaration without seeing the other, and applied
+// together they could produce a file that does not compile.
+package bothrulesfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The collision. The receiver's only other use is the c.Run, so
+// -require-testing-run would remove its declaration — while
+// -require-qt-c-receiver rewrites the qt.Assert above it into a use of exactly
+// that declaration. The declaration has to survive.
+func TestReceiverKeptForTheOtherRule(t *testing.T) {
+	c := qt.New(t)
+	qt.Assert(t, 1, qt.Equals, 1)                             // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	c.Run("sub", func(c *qt.C) { c.Assert(2, qt.Equals, 2) }) // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+}
+
+// The control. With no package-level assertion to rewrite, nothing will use
+// the declaration afterwards and it goes with the c.Run, as it did before.
+func TestReceiverStillRemovedWithoutTheOtherRule(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { c.Assert(3, qt.Equals, 3) }) // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+}

--- a/testdata/src/bothrulesfix/bothrulesfix.go.golden
+++ b/testdata/src/bothrulesfix/bothrulesfix.go.golden
@@ -1,0 +1,36 @@
+// Package bothrulesfix pins the rewrites of the two opt-in rules applied in
+// one pass.
+//
+// The order test next door uses its own fixture and keeps the two rules from
+// meeting on one receiver, so the combined FIX path had no coverage: each rule
+// plans against the same declaration without seeing the other, and applied
+// together they could produce a file that does not compile.
+package bothrulesfix
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The collision. The receiver's only other use is the c.Run, so
+// -require-testing-run would remove its declaration — while
+// -require-qt-c-receiver rewrites the qt.Assert above it into a use of exactly
+// that declaration. The declaration has to survive.
+func TestReceiverKeptForTheOtherRule(t *testing.T) {
+	c := qt.New(t)
+	c.Assert(1, qt.Equals, 1) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(2, qt.Equals, 2)
+	}) // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+}
+
+// The control. With no package-level assertion to rewrite, nothing will use
+// the declaration afterwards and it goes with the c.Run, as it did before.
+func TestReceiverStillRemovedWithoutTheOtherRule(t *testing.T) {
+	t.Run("sub", func(t *testing.T) {
+		c := qt.New(t)
+		c.Assert(3, qt.Equals, 3)
+	}) // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+}

--- a/testdata/src/datarows/datarows.go
+++ b/testdata/src/datarows/datarows.go
@@ -1,0 +1,137 @@
+package datarows
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+var errBoom = errors.New("boom")
+
+// A table row carries data. A checker in a row is the branch the table was
+// meant to remove, written out one row at a time.
+func TestRowCarriesAChecker(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr func(c *qt.C, err error) // want "qtlint: a table row carries data, not a checker; give the row the value that varies, or split the table into the tests its rows are asserting differently"
+	}{
+		{
+			name:    "no error",
+			wantErr: func(c *qt.C, err error) { c.Assert(err, qt.IsNil) },
+		},
+		{
+			name:    "an error",
+			wantErr: func(c *qt.C, err error) { c.Assert(err, qt.Equals, errBoom) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			test.wantErr(c, nil)
+		})
+	}
+}
+
+// A row doing more of the work is not an exemption. Rows whose assertions
+// differ in shape are two tests sharing one table, and the style this enforces
+// asks for them to be separate.
+func TestRowDoingSeveralThings(t *testing.T) {
+	tests := []struct {
+		name   string
+		assert func(c *qt.C, err error, out string) // want "qtlint: a table row carries data, not a checker; give the row the value that varies, or split the table into the tests its rows are asserting differently"
+	}{
+		{
+			name: "one assertion",
+			assert: func(c *qt.C, err error, _ string) {
+				c.Assert(err, qt.IsNil)
+			},
+		},
+		{
+			name: "two assertions",
+			assert: func(c *qt.C, err error, out string) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(out, qt.Equals, "x")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			test.assert(c, nil, "x")
+		})
+	}
+}
+
+// The handle rather than the checker is the same defect: what reaches the row
+// is still the means to assert.
+func TestRowCarriesAHandle(t *testing.T) {
+	tests := []struct {
+		name   string
+		assert func(tb testing.TB, err error) // want "qtlint: a table row carries data, not a checker; give the row the value that varies, or split the table into the tests its rows are asserting differently"
+	}{
+		{
+			name:   "row",
+			assert: func(tb testing.TB, err error) { qt.New(tb).Assert(err, qt.IsNil) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.assert(t, nil)
+		})
+	}
+}
+
+// A row field holding a function that asserts nothing is data the test builds
+// with, and is left alone. This is the control that keeps the rule from
+// reading "no function fields".
+//
+// It takes a parameter deliberately. A zero-parameter function never reaches
+// the type check at all, so a control written that way would pass against a
+// rule that had stopped looking at types — which is what it exists to catch.
+func TestRowCarriesAFunctionThatIsData(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(dir string) []string
+		want int
+	}{
+		{name: "none", args: func(dir string) []string { return nil }, want: 0},
+		{name: "two", args: func(dir string) []string { return []string{dir, "b"} }, want: 2},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(test.args("a"), qt.HasLen, test.want)
+		})
+	}
+}
+
+// An unnamed parameter, and a row spelling the handle differently from the
+// declaration. Neither is an exemption: the rule matches the parameter TYPE,
+// so no name has to agree with any other name for it to fire.
+func TestUnnamedAndRenamedHandles(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr func(*qt.C, error) // want "qtlint: a table row carries data, not a checker; give the row the value that varies, or split the table into the tests its rows are asserting differently"
+	}{
+		{
+			name:    "the row names it something else",
+			wantErr: func(check *qt.C, err error) { check.Assert(err, qt.IsNil) },
+		},
+		{
+			name:    "and again",
+			wantErr: func(other *qt.C, err error) { other.Assert(err, qt.Equals, errBoom) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			test.wantErr(c, nil)
+		})
+	}
+}

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -241,3 +241,19 @@ func TestUnremovableDeclDeclinesNest(t *testing.T) {
 		})
 	})
 }
+
+// Two subtests sharing one receiver whose declaration goes with them.
+//
+// Each site's fix carries the whole group, not only its own edits. A
+// SuggestedFix is the unit an editor applies, so a fix that deleted the
+// declaration and rewrote one site would leave the sibling naming a
+// declaration that is gone — accepted alone in gopls, that does not compile.
+func TestSiblingsShareOneFix(t *testing.T) {
+	c := qt.New(t)
+	c.Run("first", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(1, qt.Equals, 1)
+	})
+	c.Run("second", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(2, qt.Equals, 2)
+	})
+}

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -248,3 +248,20 @@ func TestUnremovableDeclDeclinesNest(t *testing.T) {
 		})
 	})
 }
+
+// Two subtests sharing one receiver whose declaration goes with them.
+//
+// Each site's fix carries the whole group, not only its own edits. A
+// SuggestedFix is the unit an editor applies, so a fix that deleted the
+// declaration and rewrote one site would leave the sibling naming a
+// declaration that is gone — accepted alone in gopls, that does not compile.
+func TestSiblingsShareOneFix(t *testing.T) {
+	t.Run("first", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(1, qt.Equals, 1)
+	})
+	t.Run("second", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(2, qt.Equals, 2)
+	})
+}


### PR DESCRIPTION
Three things, all about a fix being correct on its own.

## `-require-data-rows`

A table-driven test that forbids conditionals pushes the varying part into its rows. When that part is a value, the row carries a value. When a project reaches for a closure instead, the branch it could not write as an `if` reappears one row at a time:

```go
tests := []struct {
	name   string
	assert func(c *qt.C, err error)
}{
	{name: "…", assert: func(c *qt.C, err error) {
		c.Assert(err, qt.ErrorMatches, `table "public.users" is declared more than once;.*`)
	}},
	// fifty more, each three lines carrying one string
}
```

A checker in a row is the defect, whatever the closure does — rows whose assertions differ in shape are two tests sharing one table, and the style that forbids the conditional also asks for those to be separate. So there is no threshold and no row count to reach.

The field **name** is never consulted: what decides is the parameter type, so `wantErr func(*qt.C, error)` with unnamed parameters and a row spelling the handle `check` are both reported. A mutant matching on the name `assert` instead reddens the fixtures.

Measured on one repository: **192** fields in the default contour, **211** with the integration tag. Closes #71.

## Each fix now converts its whole group — closes #58

A `SuggestedFix` is the unit an editor applies. Each `c.Run` site carried the shared declaration deletion plus its own edits, which is correct only for a driver that applies all of them. Accept one code action in gopls and the declaration goes while the siblings that still name it stay:

```
before: applying the first diagnostic alone → go vet: undefined: c
after:  applying the first diagnostic alone → 7 edits, compiles, tests pass
```

A fix now rewrites every site sharing its receiver. The group's fixes are then identical, so a batch driver collapses them exactly as before.

## The two rules stop colliding — closes #65

`-require-testing-run` deletes a receiver declaration whose last use it consumed. `-require-qt-c-receiver` rewrites `qt.Assert(t, …)` into `c.Assert(…)` — a use of that same declaration. Neither is wrong alone:

```
before: both rules, one pass → go vet: undefined: c
after:  both rules, one pass → compiles, tests pass, declaration kept
```

The deletion now asks the other rule what it is about to write, when that rule is enabled in the same run. Conservative in the safe direction: a declaration kept that nothing uses is a lint finding; one removed while something does is a build failure.

`bothrulesfix` is the first fixture where the two rules meet on one receiver — the existing both-rules fixture keeps them apart on purpose, which is why the combined fix path had no coverage. Its mutant, the deletion no longer asking, reddens it.

## A defect the fixtures found

Row collection is bounded by the declaration **node**, not the type. Two anonymous struct types of the same shape are identical to `go/types`, so a type-based search hands one table the rows of another. The one-row negative fixture caught it by reporting on its two-row neighbour.

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 · `go test -race ./... -count=1` 0 · `golangci-lint run ./...` 0.