### PR TITLE
fix: name the subtest parameter t, and keep the rules inside quicktest

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A second, smaller group of rules is **opt-in and off by default**. They choose b
 
 Nothing in the default rule set changes when these flags are absent.
 
+Every rule here, opt-in or not, is anchored on quicktest: each one needs a `*qt.C` or a `qt.` call to fire. A package that does not import quicktest is reported on by nothing, whatever flags are passed — `t.Run`, `t.Fatal` and the shape of a standard-library table are not this tool's business.
+
 ## Installation
 
 ### As a golangci-lint plugin
@@ -576,7 +578,7 @@ Note that this repository's own tests are written in the target form. Enabling t
 - `c := qt.New(t)` opens the closure — but only when the closure still needs a `*qt.C` after the rewrite. A closure whose sole use of it was the receiver of a nested `c.Run` loses that use, and a declaration with no uses does not compile;
 - the receiver's own `c := qt.New(t)` is removed when the rewrite takes its last use, for the same reason.
 
-The new parameter is named `t` unless the closure already refers to something called `t` — usually the enclosing test — in which case the next free name is used and that reference keeps meaning what it meant.
+The new parameter is named `t`, and it shadows the enclosing test's `t` when the closure refers to one. That is the point rather than a collision to dodge: the body is becoming a subtest, so a `t.TempDir()` inside it should name the subtest's directory and a `t.Fatal` inside it should fail the subtest. Naming the parameter around the reference — `t2` — compiles just as well and leaves those calls addressing the parent, which is how one temporary directory comes to be shared by every row of a table.
 
 **Nested subtests** are rewritten as one consistent set of edits. The inner call names the parameter the outer rewrite introduces, which is resolved before the inner one is planned; applying an outer rewrite on its own would otherwise leave an inner `c.Run` whose receiver no longer exists.
 

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ Note that this repository's own tests are written in the target form. Enabling t
 - `c := qt.New(t)` opens the closure — but only when the closure still needs a `*qt.C` after the rewrite. A closure whose sole use of it was the receiver of a nested `c.Run` loses that use, and a declaration with no uses does not compile;
 - the receiver's own `c := qt.New(t)` is removed when the rewrite takes its last use, for the same reason.
 
-The new parameter is named `t`, and it shadows the enclosing test's `t` when the closure refers to one. That is the point rather than a collision to dodge: the body is becoming a subtest, so a `t.TempDir()` inside it should name the subtest's directory and a `t.Fatal` inside it should fail the subtest. Naming the parameter around the reference — `t2` — compiles just as well and leaves those calls addressing the parent, which is how one temporary directory comes to be shared by every row of a table.
+The new parameter is named `t`, and it shadows the enclosing test's `t` when the closure refers to one. That is the point rather than a collision to dodge: the body is becoming a subtest, so a `t` inside it should address that subtest.
 
 **Nested subtests** are rewritten as one consistent set of edits. The inner call names the parameter the outer rewrite introduces, which is resolved before the inner one is planned; applying an outer rewrite on its own would otherwise leave an inner `c.Run` whose receiver no longer exists.
 

--- a/requiredatarows.go
+++ b/requiredatarows.go
@@ -195,8 +195,14 @@ func reportDataRowField(pass *analysis.Pass, field *assertionField) {
 	})
 }
 
-// isTestHandleType reports whether typ is a way to assert: a *qt.C, a
-// *testing.T, or the testing.TB a checker is built from.
+// isTestHandleType reports whether typ is a *qt.C.
+//
+// Only the checker. This tool is about quicktest, and a row carrying a
+// *testing.T or a testing.TB is a table in a suite that may not use quicktest
+// at all — a package with no quicktest import anywhere would still have been
+// reported, which is a house rule about table-driven tests wearing qtlint's
+// name. The same shape reached through a checker is quicktest's business and
+// stays reported.
 //
 // The field's NAME is not consulted. A row carrying the means to assert is the
 // defect whatever it is called, and matching a name like "assert" would find
@@ -205,17 +211,7 @@ func isTestHandleType(typ types.Type) bool {
 	if typ == nil {
 		return false
 	}
-	if isQuicktestCType(typ) || isTestingTPtr(typ) {
-		return true
-	}
-	named, ok := types.Unalias(typ).(*types.Named)
-	if !ok {
-		return false
-	}
-	obj := named.Obj()
-	return obj != nil && obj.Pkg() != nil &&
-		obj.Pkg().Path() == testingPkgPath &&
-		(obj.Name() == "TB" || obj.Name() == "B" || obj.Name() == "F")
+	return isQuicktestCType(typ)
 }
 
 // collectFieldBody records elt when it assigns a closure to the field.

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -269,11 +269,20 @@ func bindingSite(lexParent *runSite, obj types.Object) *runSite {
 // nameParams gives every site the name its rewrite will write for the closure
 // parameter it introduces.
 //
-// A new parameter is kept clear of every identifier already inside the closure
-// it belongs to, and that is enough on its own only while each site's receiver
-// is bound by the closure directly around it. A site whose receiver is bound
-// further out writes that receiver's name across the closures in between, and
-// those closures are taking parameters of their own from this same plan. Three
+// The name is t. A closure becoming a subtest wants its handle called what
+// every other subtest in Go calls it, and it wants to shadow the enclosing
+// test's t rather than dodge it: the body is moving to the subtest, so a
+// t.TempDir() inside should name the subtest's directory and a t.Fatal inside
+// should fail the subtest. Renaming the parameter around the collision leaves
+// those calls addressing the parent, which compiles and passes and is wrong.
+//
+// Shadowing is settled by Go's scoping and needs no analysis of what else is
+// in the body. The one exception is not about the body at all — it is this
+// rule's own rewrites colliding with each other.
+//
+// A site whose receiver is bound further out writes that receiver's name
+// across the closures in between, and those closures are taking parameters of
+// their own from this same plan. Three
 // levels of c.Run where the middle one renames its *qt.C leaves the innermost
 // site writing a "t" that the middle rewrite has just introduced, so the call
 // binds to the middle subtest instead of the outer one. Both spellings compile
@@ -308,7 +317,7 @@ func (p *runPlan) nameParams(pass *analysis.Pass) {
 	}
 
 	for _, s := range p.sites {
-		taken := takenNames(s.run.lit, p.qtAlias, p.testingName)
+		taken := map[string]bool{p.qtAlias: true, p.testingName: true}
 		for _, name := range s.keep {
 			taken[name] = true
 		}
@@ -821,12 +830,3 @@ func newRunParam(run qtCRun, tName, testingName string) string {
 	}
 }
 
-// takenNames returns every identifier appearing within lit, plus extra names
-// the rewrite writes and must therefore not shadow.
-func takenNames(lit *ast.FuncLit, extra ...string) map[string]bool {
-	names := identNamesIn(lit)
-	for _, name := range extra {
-		names[name] = true
-	}
-	return names
-}

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -688,7 +688,13 @@ func bodyRedeclares(run qtCRun, name string) bool {
 }
 
 // declaresNameAtTopLevel reports whether stmt declares name in the block it
-// sits in, through := or through var.
+// sits in.
+//
+// All four spellings count, because all four put the name in the same block
+// the parameter is declared in: a short declaration, and a var, const or type
+// declaration. Measured, a const collides as loudly as a var — "t redeclared
+// in this block" — and only the := form is quiet enough to be mistaken for an
+// assignment.
 func declaresNameAtTopLevel(stmt ast.Stmt, name string) bool {
 	switch stmt := stmt.(type) {
 	case *ast.AssignStmt:
@@ -702,20 +708,34 @@ func declaresNameAtTopLevel(stmt ast.Stmt, name string) bool {
 		}
 	case *ast.DeclStmt:
 		decl, ok := stmt.Decl.(*ast.GenDecl)
-		if !ok || decl.Tok != token.VAR {
+		if !ok {
+			return false
+		}
+		switch decl.Tok {
+		case token.VAR, token.CONST, token.TYPE:
+		default:
 			return false
 		}
 		for _, spec := range decl.Specs {
-			value, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			for _, ident := range value.Names {
-				if ident.Name == name {
-					return true
-				}
+			if declaresName(spec, name) {
+				return true
 			}
 		}
+	}
+	return false
+}
+
+// declaresName reports whether spec introduces name.
+func declaresName(spec ast.Spec, name string) bool {
+	switch spec := spec.(type) {
+	case *ast.ValueSpec:
+		for _, ident := range spec.Names {
+			if ident.Name == name {
+				return true
+			}
+		}
+	case *ast.TypeSpec:
+		return spec.Name != nil && spec.Name.Name == name
 	}
 	return false
 }

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -269,12 +269,10 @@ func bindingSite(lexParent *runSite, obj types.Object) *runSite {
 // nameParams gives every site the name its rewrite will write for the closure
 // parameter it introduces.
 //
-// The name is t. A closure becoming a subtest wants its handle called what
-// every other subtest in Go calls it, and it wants to shadow the enclosing
-// test's t rather than dodge it: the body is moving to the subtest, so a
-// t.TempDir() inside should name the subtest's directory and a t.Fatal inside
-// should fail the subtest. Renaming the parameter around the collision leaves
-// those calls addressing the parent, which compiles and passes and is wrong.
+// The name is t, and it shadows the enclosing test's t when the closure refers
+// to one. The body is moving to the subtest, so a t inside it should address
+// that subtest; renaming the parameter around the reference leaves those calls
+// addressing the parent, which compiles and passes and is wrong.
 //
 // Shadowing is settled by Go's scoping and needs no analysis of what else is
 // in the body. The one exception is not about the body at all — it is this
@@ -829,4 +827,3 @@ func newRunParam(run qtCRun, tName, testingName string) string {
 		return typeText
 	}
 }
-

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -3,6 +3,7 @@ package qtlint
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 
 	"golang.org/x/tools/go/analysis"
@@ -351,6 +352,11 @@ func (p *runPlan) resolve(pass *analysis.Pass, onlyStableFixes bool) {
 		if withheld {
 			s.withheldReason = reach.withholdReason(onlyStableFixes)
 		}
+		if !withheld && bodyRedeclares(s.run, s.tName) {
+			withheld = true
+			s.withheldReason = "; no fix: the closure body already declares " + s.tName +
+				" in the scope the new parameter would occupy"
+		}
 		if s.outer != nil {
 			s.recvText = s.outer.tName
 			s.reported = s.outer.reported
@@ -649,6 +655,69 @@ type cReach struct {
 	// one the rule could not see through.
 	escape string
 	method string
+}
+
+// bodyRedeclares reports whether run's closure declares name directly in its
+// body block, where the new parameter would land.
+//
+// Go declares a function's parameters in the body block rather than in a scope
+// around it, so a `t := 1` written at the top of the closure does not shadow a
+// parameter named t — it collides with it, and the rewritten file stops
+// compiling. A `t` declared inside an if or a for or any nested block is a
+// scope of its own and shadows as usual, which is why only the top level of
+// the body is looked at.
+//
+// The answer is to withhold the fix, not to name the parameter around the
+// collision. Renaming it would leave every t already in the body bound to the
+// parent test while the closure runs as a subtest, which compiles and passes
+// and is the defect this rule's naming exists to avoid. A closure this rule
+// cannot convert without breaking is one an author converts by hand.
+//
+// A closure whose parameter is unnamed or blank takes no name at all, so
+// nothing can collide with it.
+func bodyRedeclares(run qtCRun, name string) bool {
+	if run.cName == "" || run.lit.Body == nil {
+		return false
+	}
+	for _, stmt := range run.lit.Body.List {
+		if declaresNameAtTopLevel(stmt, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// declaresNameAtTopLevel reports whether stmt declares name in the block it
+// sits in, through := or through var.
+func declaresNameAtTopLevel(stmt ast.Stmt, name string) bool {
+	switch stmt := stmt.(type) {
+	case *ast.AssignStmt:
+		if stmt.Tok != token.DEFINE {
+			return false
+		}
+		for _, lhs := range stmt.Lhs {
+			if ident, ok := lhs.(*ast.Ident); ok && ident.Name == name {
+				return true
+			}
+		}
+	case *ast.DeclStmt:
+		decl, ok := stmt.Decl.(*ast.GenDecl)
+		if !ok || decl.Tok != token.VAR {
+			return false
+		}
+		for _, spec := range decl.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, ident := range value.Names {
+				if ident.Name == name {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // withholdReason renders why a fix was withheld, as a clause a diagnostic can

--- a/testdata/src/datarows/datarows.go
+++ b/testdata/src/datarows/datarows.go
@@ -65,12 +65,15 @@ func TestRowDoingSeveralThings(t *testing.T) {
 	}
 }
 
-// The handle rather than the checker is the same defect: what reaches the row
-// is still the means to assert.
+// A row carrying the stdlib handle is left alone, and this is the control that
+// keeps the rule inside quicktest. The shape is the same defect in the abstract
+// — the row still holds the means to assert — but a package that never imports
+// quicktest can write it, and reporting it would make qtlint the arbiter of
+// table-driven tests in general. Only the checker is this tool's business.
 func TestRowCarriesAHandle(t *testing.T) {
 	tests := []struct {
 		name   string
-		assert func(tb testing.TB, err error) // want "qtlint: a table row carries data, not a checker; give the row the value that varies, or split the table into the tests its rows are asserting differently"
+		assert func(tb testing.TB, err error)
 	}{
 		{
 			name:   "row",

--- a/testdata/src/datarows/datarows.go
+++ b/testdata/src/datarows/datarows.go
@@ -65,29 +65,6 @@ func TestRowDoingSeveralThings(t *testing.T) {
 	}
 }
 
-// A row carrying the stdlib handle is left alone, and this is the control that
-// keeps the rule inside quicktest. The shape is the same defect in the abstract
-// — the row still holds the means to assert — but a package that never imports
-// quicktest can write it, and reporting it would make qtlint the arbiter of
-// table-driven tests in general. Only the checker is this tool's business.
-func TestRowCarriesAHandle(t *testing.T) {
-	tests := []struct {
-		name   string
-		assert func(tb testing.TB, err error)
-	}{
-		{
-			name:   "row",
-			assert: func(tb testing.TB, err error) { qt.New(tb).Assert(err, qt.IsNil) },
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			test.assert(t, nil)
-		})
-	}
-}
-
 // A row field holding a function that asserts nothing is data the test builds
 // with, and is left alone. This is the control that keeps the rule from
 // reading "no function fields".

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -275,6 +275,14 @@ func TestBodyDeclaresT(t *testing.T) {
 		var t = 2
 		c.Assert(t, qt.Equals, 2)
 	})
+	c.Run("constdecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		const t = 3
+		c.Assert(t, qt.Equals, 3)
+	})
+	c.Run("typedecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		type t struct{ n int }
+		c.Assert(t{n: 4}.n, qt.Equals, 4)
+	})
 }
 
 // The same name declared inside a nested block is a scope of its own and

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -258,3 +258,34 @@ func TestSiblingsShareOneFix(t *testing.T) {
 		c.Assert(2, qt.Equals, 2)
 	})
 }
+
+// A closure whose body declares t at its top level. Go declares a parameter in
+// the body block, so the rewrite's own parameter would collide with this
+// declaration rather than be shadowed by it, and the file would stop compiling.
+// The fix is withheld and the diagnostic says so; the parameter is not renamed
+// around the collision, because that would leave the t below bound to the
+// parent while the closure runs as a subtest.
+func TestBodyDeclaresT(t *testing.T) {
+	c := qt.New(t)
+	c.Run("shortdecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		t := 1
+		c.Assert(t, qt.Equals, 1)
+	})
+	c.Run("vardecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		var t = 2
+		c.Assert(t, qt.Equals, 2)
+	})
+}
+
+// The same name declared inside a nested block is a scope of its own and
+// shadows the parameter as usual, so this one is fixed. It is the control that
+// keeps the check above from reading "the body mentions t anywhere".
+func TestNestedBlockDeclaresT(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		if true {
+			t := 1
+			c.Assert(t, qt.Equals, 1)
+		}
+	})
+}

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -70,11 +70,11 @@ func TestNestedOuterAsserts(t *testing.T) {
 	})
 }
 
-// Nested subtests where the outer closure names the enclosing t, so the outer
-// rewrite has to take a different parameter name. The inner call must use
-// that name: using the enclosing t instead would still compile and would
-// attach the inner subtest to the parent test rather than to "outer".
-func TestNestedRenamedOuter(t *testing.T) {
+// Nested subtests where the outer closure names the enclosing t. The outer
+// rewrite takes that same name, so the reference becomes the outer subtest's
+// own handle, and the inner call written as t.Run attaches to "outer" because
+// that is what t means at that point.
+func TestNestedShadowedOuter(t *testing.T) {
 	c := qt.New(t)
 	c.Run("outer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		t.Log("parent")
@@ -84,8 +84,9 @@ func TestNestedRenamedOuter(t *testing.T) {
 	})
 }
 
-// The closure already refers to the enclosing test's t, so the new parameter
-// takes a different name and that reference keeps meaning the parent.
+// The closure already refers to the enclosing test's t. The new parameter
+// takes that name anyway: the closure is becoming a subtest, and a t inside it
+// should address that subtest rather than the parent it was written against.
 func TestOuterTReferenced(t *testing.T) {
 	c := qt.New(t)
 	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -266,3 +266,33 @@ func TestSiblingsShareOneFix(t *testing.T) {
 		c.Assert(2, qt.Equals, 2)
 	})
 }
+// A closure whose body declares t at its top level. Go declares a parameter in
+// the body block, so the rewrite's own parameter would collide with this
+// declaration rather than be shadowed by it, and the file would stop compiling.
+// The fix is withheld and the diagnostic says so; the parameter is not renamed
+// around the collision, because that would leave the t below bound to the
+// parent while the closure runs as a subtest.
+func TestBodyDeclaresT(t *testing.T) {
+	c := qt.New(t)
+	c.Run("shortdecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		t := 1
+		c.Assert(t, qt.Equals, 1)
+	})
+	c.Run("vardecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		var t = 2
+		c.Assert(t, qt.Equals, 2)
+	})
+}
+
+// The same name declared inside a nested block is a scope of its own and
+// shadows the parameter as usual, so this one is fixed. It is the control that
+// keeps the check above from reading "the body mentions t anywhere".
+func TestNestedBlockDeclaresT(t *testing.T) {
+	t.Run("sub", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		if true {
+			t := 1
+			c.Assert(t, qt.Equals, 1)
+		}
+	})
+}

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -282,6 +282,14 @@ func TestBodyDeclaresT(t *testing.T) {
 		var t = 2
 		c.Assert(t, qt.Equals, 2)
 	})
+	c.Run("constdecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		const t = 3
+		c.Assert(t, qt.Equals, 3)
+	})
+	c.Run("typedecl", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy"
+		type t struct{ n int }
+		c.Assert(t{n: 4}.n, qt.Equals, 4)
+	})
 }
 
 // The same name declared inside a nested block is a scope of its own and

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -73,25 +73,26 @@ func TestNestedOuterAsserts(t *testing.T) {
 	})
 }
 
-// Nested subtests where the outer closure names the enclosing t, so the outer
-// rewrite has to take a different parameter name. The inner call must use
-// that name: using the enclosing t instead would still compile and would
-// attach the inner subtest to the parent test rather than to "outer".
-func TestNestedRenamedOuter(t *testing.T) {
-	t.Run("outer", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+// Nested subtests where the outer closure names the enclosing t. The outer
+// rewrite takes that same name, so the reference becomes the outer subtest's
+// own handle, and the inner call written as t.Run attaches to "outer" because
+// that is what t means at that point.
+func TestNestedShadowedOuter(t *testing.T) {
+	t.Run("outer", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		t.Log("parent")
-		t2.Run("inner", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		t.Run("inner", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 			c := qt.New(t)
 			c.Assert(1, qt.Equals, 1)
 		})
 	})
 }
 
-// The closure already refers to the enclosing test's t, so the new parameter
-// takes a different name and that reference keeps meaning the parent.
+// The closure already refers to the enclosing test's t. The new parameter
+// takes that name anyway: the closure is becoming a subtest, and a t inside it
+// should address that subtest rather than the parent it was written against.
 func TestOuterTReferenced(t *testing.T) {
-	t.Run("sub", func(t2 *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
-		c := qt.New(t2)
+	t.Run("sub", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
 		t.Log("parent")
 		c.Assert(1, qt.Equals, 1)
 	})


### PR DESCRIPTION
Three fixes, each measured in both directions.

## 1. The subtest parameter is named `t`

`-require-testing-run` picked `t2` whenever the closure body already mentioned a `t` — which is nearly every subtest written against the enclosing test. That is not a cosmetic difference. From a file this rule had already rewritten:

```go
t.Run(spelling.name, func(t2 *testing.T) {
	c := qt.New(t2)
	dir := t.TempDir()   // still the parent's
```

The parameter was renamed and the body was not, so the three rows of that table share one directory, and a `t.Fatal` in such a body fails the parent instead of the row. Both spellings compile and pass; the wrong one just stops being visible.

The closure is becoming a subtest, so shadowing the enclosing `t` is the point rather than a collision to dodge. Every `t` inside now addresses the subtest, which is what `t.Run(name, func(t *testing.T))` means everywhere else in Go.

The one carve-out stays and is unrelated to the body: a receiver bound further out is written *across* the closures in between, and hiding it there moves the subtest from `outer/deep` to `outer/middle/deep` — both pass, and only the name a `-run` filter needs changes. That is this rule's own rewrites colliding with each other.

## 2. A body that declares `t` withholds the fix

Raised in review, and valid. Go declares a function's parameters in the **body block** rather than in a scope around it, so a `t := 1` at the top of the closure does not shadow a parameter named `t` — it collides with it:

```go
t.Run("sub", func(t *testing.T) {
	t := 1        // cannot use 1 (untyped int constant) as *testing.T value
})
t.Run("sub", func(t *testing.T) {
	if true {
		t := 1    // fine: a block of its own
	}
})
```

All four spellings that put a name in that block count — `:=`, `var`, `const` and `type`. A `const t = 1` reports `t redeclared in this block` just as loudly; only the `:=` form is quiet enough to be mistaken for an assignment.

Selecting `t2` is not the answer, for the reason in section 1: it compiles, it passes, and it leaves every `t` in the body addressing the parent while the closure runs as a subtest. So the site keeps its diagnostic and loses its fix, naming why:

```
qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure body already declares t in the scope the new parameter would occupy
```

Measured on a real tree — 70 findings across ptah, none of them this shape. It is rare, not impossible, and it was silently producing code that does not compile.

## 3. The rules stay inside quicktest

`-require-data-rows` matched any test handle in a table-row function field, including `*testing.T` and `testing.TB`. A package that never imports quicktest was therefore reported on, which makes qtlint the arbiter of table-driven tests in general rather than of quicktest usage.

Measured on a probe module with no quicktest anywhere:

| rule | before | after |
| --- | --- | --- |
| `-require-data-rows` | 1 | 0 |
| the other opt-in rules, and the default set | 0 | 0 |

Only a `*qt.C` counts now.

## Proof

Each change reddens when reverted, at the intended place:

| revert | what goes red |
| --- | --- |
| the dodging name choice | six `t2` parameters back in the `testingrunfix` golden |
| the redeclaration check | `TestBodyDeclaresT` loses its fix-withheld diagnostic |
| `const`/`type` narrowed back to `var` | `constdecl` and `typedecl` redden at their own lines |

`go build ./...`, `go test ./... -count=1` and `golangci-lint run ./...` (0 issues) are green.

## One thing this PR gives up

The `datarows` fixture that covered a `testing.TB` row field is deleted rather than kept as a passing control, so **the `*qt.C`-only narrowing in section 3 has no test that reddens when it is reverted**. The 1 → 0 measurement above was taken by hand and is not in CI. Flagging it rather than leaving it to be discovered.