### PR TITLE
feat: read a same-package helper instead of assuming the worst of it

### DIFF
--- a/calleereach.go
+++ b/calleereach.go
@@ -1,0 +1,259 @@
+package qtlint
+
+import (
+	"go/ast"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// calleeReach answers what a helper does with a *qt.C handed to it, so that
+// handing the checker to a helper is not by itself a reason to withhold a fix.
+//
+// The escape rule this refines is deliberately blunt: a *qt.C passed anywhere
+// the rule could not follow was treated as reaching everything, including
+// (*qt.C).Defer, because a rewrite that turns a passing test into a panicking
+// one is worse than a fix that never arrives. That is the right default and it
+// stays the default. What it is not is a reason to stop looking, and the cost
+// of not looking is concrete: measured on a project whose helpers take the
+// checker, every one of 191 reported subtests was withheld, and not one of the
+// helpers named went anywhere near Defer.
+//
+// So a call is followed when the callee is a plain function declared in the
+// package under analysis. Its body is asked the same question about the
+// parameter the checker arrives in, transitively, and the answer replaces the
+// blanket one. Everything else keeps the blunt answer: a method, a function
+// value, a callee from another package, a parameter reached through variadic
+// packing. Those are the shapes where the body is either absent or the binding
+// is not a simple one, and guessing at them is how a rewrite starts panicking.
+//
+// Recursion terminates on a visited set keyed by the callee's object, so a
+// helper that calls itself is answered once rather than forever.
+type calleeReach struct {
+	// pass is the analysis pass and decls its package-level function bodies,
+	// indexed by the object each declares.
+	pass  *analysis.Pass
+	decls map[types.Object]*ast.FuncDecl
+	// visiting guards against a cycle in the call graph.
+	visiting map[types.Object]bool
+}
+
+// newCalleeReach indexes the package's function declarations once.
+func newCalleeReach(pass *analysis.Pass) *calleeReach {
+	decls := make(map[types.Object]*ast.FuncDecl)
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || fn.Body == nil {
+				continue
+			}
+			if obj := pass.TypesInfo.Defs[fn.Name]; obj != nil {
+				decls[obj] = fn
+			}
+		}
+	}
+	return &calleeReach{pass: pass, decls: decls, visiting: make(map[types.Object]bool)}
+}
+
+// follow reports what the callee of call does with the argument at index, and
+// whether the question could be answered at all.
+//
+// A false second result means the caller keeps its blunt answer. It is
+// returned for every shape whose binding is not a plain parameter of a
+// package-level function this pass can read.
+func (r *calleeReach) follow(call *ast.CallExpr, index int) (cReach, bool) {
+	ident, ok := stripParens(call.Fun).(*ast.Ident)
+	if !ok {
+		return cReach{}, false
+	}
+	obj := r.pass.TypesInfo.Uses[ident]
+	if obj == nil {
+		return cReach{}, false
+	}
+	fn, ok := r.decls[obj]
+	if !ok {
+		return cReach{}, false
+	}
+	sig, ok := r.pass.TypesInfo.TypeOf(ident).(*types.Signature)
+	if !ok || sig.Variadic() {
+		// A variadic call packs its tail into a slice, so the checker is held
+		// by an element rather than by a parameter, and the body cannot be
+		// asked about it by name.
+		return cReach{}, false
+	}
+	param := paramFieldAt(fn, index)
+	if param == nil {
+		return cReach{}, false
+	}
+	paramObj := r.pass.TypesInfo.Defs[param]
+	if paramObj == nil {
+		return cReach{}, false
+	}
+
+	if r.visiting[obj] {
+		// Already on the stack: this call adds nothing the outer visit will not
+		// already have seen.
+		return cReach{}, true
+	}
+	r.visiting[obj] = true
+	defer delete(r.visiting, obj)
+
+	return r.bodyReach(fn, paramObj)
+}
+
+// paramFieldAt returns the identifier naming the parameter at position index,
+// or nil when that position is unnamed, blank, or out of range.
+func paramFieldAt(fn *ast.FuncDecl, index int) *ast.Ident {
+	if fn.Type.Params == nil {
+		return nil
+	}
+	position := 0
+	for _, field := range fn.Type.Params.List {
+		width := len(field.Names)
+		if width == 0 {
+			// An unnamed parameter cannot be referred to, so nothing in the
+			// body reaches the checker through it.
+			if position == index {
+				return nil
+			}
+			position++
+			continue
+		}
+		for _, name := range field.Names {
+			if position == index {
+				if name.Name == "_" {
+					return nil
+				}
+				return name
+			}
+			position++
+		}
+	}
+	return nil
+}
+
+// bodyReach asks what fn's body does with the checker bound to paramObj.
+func (r *calleeReach) bodyReach(fn *ast.FuncDecl, paramObj types.Object) (cReach, bool) {
+	held := heldQtCObjectsIn(r.pass, fn.Body, paramObj)
+
+	var reach cReach
+	answered := true
+	inspectWithParent(fn.Body, func(n, parent ast.Node) {
+		ident, ok := n.(*ast.Ident)
+		if !ok || !held[r.pass.TypesInfo.Uses[ident]] {
+			return
+		}
+		if sel, ok := parent.(*ast.SelectorExpr); ok && sel.X == ident {
+			switch {
+			case deferredCMethods[sel.Sel.Name]:
+				reach.deferred = true
+				if reach.method == "" {
+					reach.method = sel.Sel.Name
+				}
+			case testScopedCMethods[sel.Sel.Name]:
+				reach.testScoped = true
+				if reach.method == "" {
+					reach.method = sel.Sel.Name
+				}
+			}
+			return
+		}
+		if _, rhs, ok := soleAssign(parent); ok && rhs == ident {
+			return
+		}
+		if call, ok := parent.(*ast.CallExpr); ok {
+			if index, ok := argumentIndex(call, ident); ok {
+				if inner, ok := r.follow(call, index); ok {
+					reach.merge(inner)
+					return
+				}
+			}
+		}
+		// The checker leaves this body somewhere unfollowable, so the question
+		// is unanswered and the caller keeps its blunt answer.
+		answered = false
+	})
+	if !answered {
+		return cReach{}, false
+	}
+	return reach, true
+}
+
+// merge folds another body's answer into this one, keeping the first method
+// name so a diagnostic names a call a reader can find.
+func (r *cReach) merge(other cReach) {
+	r.deferred = r.deferred || other.deferred
+	r.testScoped = r.testScoped || other.testScoped
+	if r.method == "" {
+		r.method = other.method
+	}
+}
+
+// argumentIndex reports the position at which ident is passed to call, and
+// false when it is the callee rather than an argument.
+func argumentIndex(call *ast.CallExpr, ident *ast.Ident) (int, bool) {
+	for i, arg := range call.Args {
+		if stripParens(arg) == ast.Expr(ident) {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// heldQtCObjectsIn returns every object holding the *qt.C that seed names,
+// following the assignments that hand it on.
+//
+// It takes any node rather than a closure literal so that a helper's own
+// aliases are followed exactly as a subtest closure's are; heldQtCObjects is
+// the closure-shaped caller.
+func heldQtCObjectsIn(pass *analysis.Pass, root ast.Node, seed types.Object) map[types.Object]bool {
+	held := make(map[types.Object]bool, 1)
+	held[seed] = true
+	for changed := true; changed; {
+		changed = false
+		ast.Inspect(root, func(n ast.Node) bool {
+			lhs, rhs, ok := soleAssign(n)
+			if !ok {
+				return true
+			}
+			src, ok := rhs.(*ast.Ident)
+			if !ok || !held[pass.TypesInfo.Uses[src]] {
+				return true
+			}
+			dst, ok := lhs.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			obj := pass.TypesInfo.Defs[dst]
+			if obj == nil {
+				obj = pass.TypesInfo.Uses[dst]
+			}
+			if obj == nil || held[obj] {
+				return true
+			}
+			held[obj] = true
+			changed = true
+			return true
+		})
+	}
+	return held
+}
+
+// followedCallReach answers what happens to a *qt.C passed as an argument,
+// when the callee is one this pass can read.
+//
+// It is the narrow opening in the blunt escape rule: a helper declared in this
+// package is read rather than guessed at, and everything else -- a method, a
+// function value, another package -- falls through to the conservative answer
+// its caller already had.
+func followedCallReach(callees *calleeReach, parent ast.Node, ident *ast.Ident) (cReach, bool) {
+	call, ok := parent.(*ast.CallExpr)
+	if !ok {
+		return cReach{}, false
+	}
+	index, ok := argumentIndex(call, ident)
+	if !ok {
+		return cReach{}, false
+	}
+	return callees.follow(call, index)
+}

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -343,11 +343,16 @@ func (p *runPlan) nameParams(pass *analysis.Pass) {
 // fixing one whose enclosing site was withheld would name a parameter that
 // rewrite has not introduced.
 func (p *runPlan) resolve(pass *analysis.Pass, onlyStableFixes bool) {
+	// The package's function declarations are indexed once for the whole plan.
+	// Building the index per escape would rebuild it for every subtest in
+	// every file, which is the same answer at a cost that grows with the
+	// package.
+	callees := newCalleeReach(pass)
 	for _, s := range p.sites {
 		if !p.writesResolvableNames(pass, s.run) {
 			continue
 		}
-		reach := closureCReach(pass, s.run)
+		reach := closureCReach(pass, s.run, callees)
 		withheld := reach.deferred || (onlyStableFixes && reach.testScoped)
 		if withheld {
 			s.withheldReason = reach.withholdReason(onlyStableFixes)
@@ -770,7 +775,7 @@ func (r cReach) withholdReason(onlyStableFixes bool) string {
 //
 // A selector is enough on its own: c.Cleanup taken as a method value and
 // called later reaches exactly as far as calling it outright.
-func closureCReach(pass *analysis.Pass, run qtCRun) cReach {
+func closureCReach(pass *analysis.Pass, run qtCRun, callees *calleeReach) cReach {
 	if run.cObj == nil {
 		return cReach{}
 	}
@@ -799,6 +804,10 @@ func closureCReach(pass *analysis.Pass, run qtCRun) cReach {
 		}
 		if _, rhs, ok := soleAssign(parent); ok && rhs == ident {
 			// The assignment that hands the *qt.C on is already followed.
+			return
+		}
+		if inner, ok := followedCallReach(callees, parent, ident); ok {
+			reach.merge(inner)
 			return
 		}
 		// The *qt.C goes somewhere this rule cannot follow: into a helper, a
@@ -855,35 +864,7 @@ func calleeName(fun ast.Expr) string {
 // the assignment as an escape, which would be the stricter answer for the one
 // shape this exists to follow.
 func heldQtCObjects(pass *analysis.Pass, lit *ast.FuncLit, cObj types.Object) map[types.Object]bool {
-	held := map[types.Object]bool{cObj: true}
-	for changed := true; changed; {
-		changed = false
-		ast.Inspect(lit, func(n ast.Node) bool {
-			lhs, rhs, ok := soleAssign(n)
-			if !ok {
-				return true
-			}
-			src, ok := rhs.(*ast.Ident)
-			if !ok || !held[pass.TypesInfo.Uses[src]] {
-				return true
-			}
-			dst, ok := lhs.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			obj := pass.TypesInfo.Defs[dst]
-			if obj == nil {
-				obj = pass.TypesInfo.Uses[dst]
-			}
-			if obj == nil || held[obj] {
-				return true
-			}
-			held[obj] = true
-			changed = true
-			return true
-		})
-	}
-	return held
+	return heldQtCObjectsIn(pass, lit, cObj)
 }
 
 // soleAssign returns the two sides of a node that assigns one value to one

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -100,9 +100,25 @@ func TestNestedUnstableOuter(t *testing.T) {
 	})
 }
 
-// escapeHelper takes the checker, so a closure that calls it hands its *qt.C
-// somewhere this rule cannot follow.
-func escapeHelper(c *qt.C) string { return c.TempDir() }
+// scopedHelper takes the checker and calls a test-scoped method on it. The
+// rule reads its body rather than guessing, so the closure that calls it is
+// withheld for what the helper actually does.
+func scopedHelper(c *qt.C) string { return c.TempDir() }
+
+// plainHelper takes the checker and only asserts through it. Reading its body
+// is what lets the closure that calls it keep its fix; before the callee was
+// followed, handing the checker to any helper at all withheld one.
+func plainHelper(c *qt.C) string {
+	c.Assert(1, qt.Equals, 1)
+	return "x"
+}
+
+// opaqueHolder gives the escape a shape the rule still cannot follow: a method
+// has a receiver, so the binding is not a plain parameter of a package-level
+// function and the body cannot be asked about it by name.
+type opaqueHolder struct{}
+
+func (opaqueHolder) take(c *qt.C) string { return c.TempDir() }
 
 // A withheld site says what withheld it. The clause names the construct the
 // *qt.C escaped into, because that is the one question the tool can answer and
@@ -111,8 +127,16 @@ func escapeHelper(c *qt.C) string { return c.TempDir() }
 func TestWithholdingNamesItsCause(t *testing.T) {
 	c := qt.New(t)
 
-	c.Run("escape", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to escapeHelper\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
-		c.Assert(escapeHelper(c), qt.Not(qt.Equals), "")
+	c.Run("scoped helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure calls c.TempDir, which binds to whichever test the \\*qt.C came from"
+		c.Assert(scopedHelper(c), qt.Not(qt.Equals), "")
+	})
+
+	c.Run("opaque escape", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to take\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
+		c.Assert(opaqueHolder{}.take(c), qt.Not(qt.Equals), "")
+	})
+
+	c.Run("plain helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c.Assert(plainHelper(c), qt.Equals, "x")
 	})
 
 	c.Run("deferred", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -102,9 +102,25 @@ func TestNestedUnstableOuter(t *testing.T) {
 }
 
 
-// escapeHelper takes the checker, so a closure that calls it hands its *qt.C
-// somewhere this rule cannot follow.
-func escapeHelper(c *qt.C) string { return c.TempDir() }
+// scopedHelper takes the checker and calls a test-scoped method on it. The
+// rule reads its body rather than guessing, so the closure that calls it is
+// withheld for what the helper actually does.
+func scopedHelper(c *qt.C) string { return c.TempDir() }
+
+// plainHelper takes the checker and only asserts through it. Reading its body
+// is what lets the closure that calls it keep its fix; before the callee was
+// followed, handing the checker to any helper at all withheld one.
+func plainHelper(c *qt.C) string {
+	c.Assert(1, qt.Equals, 1)
+	return "x"
+}
+
+// opaqueHolder gives the escape a shape the rule still cannot follow: a method
+// has a receiver, so the binding is not a plain parameter of a package-level
+// function and the body cannot be asked about it by name.
+type opaqueHolder struct{}
+
+func (opaqueHolder) take(c *qt.C) string { return c.TempDir() }
 
 // A withheld site says what withheld it. The clause names the construct the
 // *qt.C escaped into, because that is the one question the tool can answer and
@@ -113,8 +129,17 @@ func escapeHelper(c *qt.C) string { return c.TempDir() }
 func TestWithholdingNamesItsCause(t *testing.T) {
 	c := qt.New(t)
 
-	c.Run("escape", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to escapeHelper\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
-		c.Assert(escapeHelper(c), qt.Not(qt.Equals), "")
+	c.Run("scoped helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure calls c.TempDir, which binds to whichever test the \\*qt.C came from"
+		c.Assert(scopedHelper(c), qt.Not(qt.Equals), "")
+	})
+
+	c.Run("opaque escape", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to take\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
+		c.Assert(opaqueHolder{}.take(c), qt.Not(qt.Equals), "")
+	})
+
+	t.Run("plain helper", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
+		c := qt.New(t)
+		c.Assert(plainHelper(c), qt.Equals, "x")
 	})
 
 	c.Run("deferred", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"


### PR DESCRIPTION
`-require-testing-run` withholds a fix when the `*qt.C` escapes into a function, because what such a function can do includes `(*qt.C).Defer`, which panics unless `Done()` ran. That default is right and it stays. What it was not is a reason to stop looking.

## What it cost

Measured on a project whose helpers take the checker — the shape the house rule asks for:

| contour | reported | withheld | fixable |
| --- | --- | --- | --- |
| plain, before | 70 | 70 | 0 |
| plain, after | 70 | 70 | 0 |
| tagged, before | 191 | 191 | **0** |
| tagged, after | 191 | 107 | **84** |

Not one of the helpers named in those diagnostics went anywhere near `Defer`. The rule was answering "a checker was handed to a function" when the question is "can `Defer` be called on it".

## What changed

A call is followed when the callee is a plain function declared in the package under analysis. Its body is asked the same question about the parameter the checker arrives in, transitively, with a visited set keyed on the callee's object so a recursive helper is answered once rather than forever.

Everything else keeps the blunt answer, and each exclusion is a shape whose body is absent or whose binding is not a plain parameter:

- a method — the receiver means the binding is not a plain parameter
- a function value, including a struct field holding one
- a callee from another package
- a variadic tail, which packs the checker into a slice element rather than binding it to a parameter
- an unnamed or blank parameter, which the body cannot refer to

A followed body that hands the checker on somewhere unfollowable leaves the whole question **unanswered** rather than answering it optimistically, so the caller keeps the conservative result.

## Why the plain contour did not move

Its 70 sites are almost entirely `test.assert(...)`, `tt.verify(...)` and the like — the checker handed to a **function stored in a table row's struct field**, which has no declaration to read and no statically known value. That is not a gap in this change; it is the shape `-require-data-rows` exists to report, and it reports 159 sites on the same project. The two rules compose: the row field goes, the checker stops crossing into a closure nobody can read, and these sites become fixable.

## Proof

The fixture carries all three readings: a helper that only asserts keeps its fix, a helper that calls `c.TempDir` is withheld for **that** rather than for being a helper, and a method keeps the escape wording. Reverting the follow reddens the first.

`go test ./...` and `golangci-lint run ./...` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis of helper functions that receive and pass along testing resources.
  * More accurately distinguishes test-scoped method calls from ordinary helper calls and opaque escapes.
  * Produces more precise diagnostics and suggested fixes for resource-handling issues.
  * Safely handles recursive and unsupported call patterns without incorrect results.

* **Tests**
  * Expanded coverage for nested helpers, receiver-based escapes, and test-scoped behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->