### PR TITLE
feat: answer by parameter type when the checker crosses into something else

### DIFF
--- a/calleereach.go
+++ b/calleereach.go
@@ -74,7 +74,13 @@ func (r *calleeReach) follow(call *ast.CallExpr, index int) (cReach, bool) {
 	// The test-scoped methods are a different matter and stay conservative:
 	// Cleanup, TempDir, Setenv and the rest belong to testing.TB itself, so a
 	// TB-typed parameter reaches them and -only-stable-fixes must still say so.
-	if param, ok := r.paramTypeAt(call, index); ok && !isQuicktestCType(param) {
+	//
+	// An interface or type parameter whose own method set names both Defer and
+	// Done is not covered by any of that: whatever satisfies it can still be a
+	// *qt.C, and the parameter's declared type lets the body call those methods
+	// by name whether or not the argument is a *qt.C underneath. That shape
+	// keeps the blunt answer instead of the type-only one.
+	if param, ok := r.paramTypeAt(call, index); ok && !isQuicktestCType(param) && !hasDeferAndDoneMethodSet(param) {
 		return cReach{testScoped: true, handedOn: true}, true
 	}
 
@@ -115,6 +121,32 @@ func (r *calleeReach) follow(call *ast.CallExpr, index int) (cReach, bool) {
 	defer delete(r.visiting, obj)
 
 	return r.bodyReach(fn, paramObj)
+}
+
+// hasDeferAndDoneMethodSet reports whether t's method set names both Defer
+// and Done, the shape of an interface or type parameter that (*qt.C)
+// satisfies without being one. A parameter of this shape can still call
+// (*qt.C).Defer on whatever *qt.C is handed to it, so it must not take the
+// type-only shortcut that treats a non-*qt.C parameter as safe.
+//
+// The check is by name only, matching how bodyReach itself decides a use is
+// deferredCMethods or testScopedCMethods: this rule has never matched a
+// method's signature, only its name.
+func hasDeferAndDoneMethodSet(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	set := types.NewMethodSet(t)
+	var hasDefer, hasDone bool
+	for i := 0; i < set.Len(); i++ {
+		switch set.At(i).Obj().Name() {
+		case "Defer":
+			hasDefer = true
+		case "Done":
+			hasDone = true
+		}
+	}
+	return hasDefer && hasDone
 }
 
 // paramFieldAt returns the identifier naming the parameter at position index,
@@ -283,7 +315,15 @@ func (r *calleeReach) paramTypeAt(call *ast.CallExpr, index int) (types.Type, bo
 	if typ == nil {
 		return nil, false
 	}
-	sig, ok := types.Unalias(typ).(*types.Signature)
+	unaliased := types.Unalias(typ)
+	sig, ok := unaliased.(*types.Signature)
+	if !ok {
+		// A defined function type -- e.g. a named type used for a struct
+		// field or variable -- is not itself a *types.Signature, but its
+		// underlying type is, and the argument still binds to that
+		// signature's parameter the same way.
+		sig, ok = unaliased.Underlying().(*types.Signature)
+	}
 	if !ok {
 		return nil, false
 	}

--- a/calleereach.go
+++ b/calleereach.go
@@ -62,26 +62,41 @@ func newCalleeReach(pass *analysis.Pass) *calleeReach {
 // returned for every shape whose binding is not a plain parameter of a
 // package-level function this pass can read.
 func (r *calleeReach) follow(call *ast.CallExpr, index int) (cReach, bool) {
-	// A parameter that is not a *qt.C answers the question by its type alone.
+	// A parameter whose type cannot name the deferred methods answers the
+	// question by its type alone.
 	//
-	// Defer and Done are C's own methods. A callee that receives the checker as
-	// a testing.TB -- or as any interface C satisfies -- cannot name them, so
-	// the hazard this rule guards is unreachable there whatever the body does,
-	// and the body does not have to be readable for that to hold. It closes the
-	// shapes no body-reading can: a function value in a struct field, a
-	// parameter of a callee from another package, a locally bound closure.
+	// Defer and Done are C's own. A callee that receives the checker as a
+	// testing.TB cannot name them, so the hazard is unreachable there whatever
+	// the body does, and the body does not have to be readable for that to
+	// hold. It closes the shapes no body-reading can: a function value in a
+	// struct field, a parameter of a callee from another package, a locally
+	// bound closure.
 	//
-	// The test-scoped methods are a different matter and stay conservative:
-	// Cleanup, TempDir, Setenv and the rest belong to testing.TB itself, so a
-	// TB-typed parameter reaches them and -only-stable-fixes must still say so.
+	// The question is the parameter's method set, not its identity. An
+	// interface or type parameter that declares Defer itself is satisfied by a
+	// *qt.C and lets the body call the method by name whether or not the
+	// argument is one underneath, so asking "is this a *qt.C" would answer
+	// "safe" there and drop the one hazard this rule exists to keep -- silently,
+	// because a subtest whose deferred function stops running does not fail.
+	// Asking the method set also covers *Alias where the alias resolves to C,
+	// and makes a separate identity check unnecessary, because C names Defer
+	// itself.
 	//
-	// An interface or type parameter whose own method set names both Defer and
-	// Done is not covered by any of that: whatever satisfies it can still be a
-	// *qt.C, and the parameter's declared type lets the body call those methods
-	// by name whether or not the argument is a *qt.C underneath. That shape
-	// keeps the blunt answer instead of the type-only one.
-	if param, ok := r.paramTypeAt(call, index); ok && !isQuicktestCType(param) && !hasDeferAndDoneMethodSet(param) {
-		return cReach{testScoped: true, handedOn: true}, true
+	// A single deferred method is enough to withhold. Requiring the parameter
+	// to name the whole API would let `interface{ Defer(func()) }` back through
+	// the shortcut, and one unrun deferred function is the whole hazard.
+	//
+	// What a parameter type bounds is what the callee can name THROUGH it. A
+	// callee that converts the value back to *qt.C names the concrete type
+	// itself, and no parameter type bounds that; the rule treats a conversion
+	// it cannot follow here as it does everywhere else.
+	//
+	// The test-scoped methods are answered the same way rather than assumed:
+	// Cleanup, TempDir and Setenv belong to testing.TB, so a TB-typed parameter
+	// reaches them and -only-stable-fixes must still say so, while a parameter
+	// that names none of them withholds nothing.
+	if param, ok := r.paramTypeAt(call, index); ok && !namesAnyMethod(param, deferredCMethods) {
+		return cReach{testScoped: namesAnyMethod(param, testScopedCMethods), handedOn: true}, true
 	}
 
 	ident, ok := stripParens(call.Fun).(*ast.Ident)
@@ -123,30 +138,27 @@ func (r *calleeReach) follow(call *ast.CallExpr, index int) (cReach, bool) {
 	return r.bodyReach(fn, paramObj)
 }
 
-// hasDeferAndDoneMethodSet reports whether t's method set names both Defer
-// and Done, the shape of an interface or type parameter that (*qt.C)
-// satisfies without being one. A parameter of this shape can still call
-// (*qt.C).Defer on whatever *qt.C is handed to it, so it must not take the
-// type-only shortcut that treats a non-*qt.C parameter as safe.
+// namesAnyMethod reports whether any of names is in t's method set, so a
+// parameter is asked what can be called through it rather than what it is.
 //
 // The check is by name only, matching how bodyReach itself decides a use is
 // deferredCMethods or testScopedCMethods: this rule has never matched a
 // method's signature, only its name.
-func hasDeferAndDoneMethodSet(t types.Type) bool {
+//
+// A nil pkg restricts the lookup to exported names, which is what every name
+// here is: these are quicktest's and testing.TB's own API.
+func namesAnyMethod(t types.Type, names map[string]bool) bool {
 	if t == nil {
 		return false
 	}
-	set := types.NewMethodSet(t)
-	var hasDefer, hasDone bool
-	for i := 0; i < set.Len(); i++ {
-		switch set.At(i).Obj().Name() {
-		case "Defer":
-			hasDefer = true
-		case "Done":
-			hasDone = true
+	for name := range names {
+		if obj, _, _ := types.LookupFieldOrMethod(t, true, nil, name); obj != nil {
+			if _, isMethod := obj.(*types.Func); isMethod {
+				return true
+			}
 		}
 	}
-	return hasDefer && hasDone
+	return false
 }
 
 // paramFieldAt returns the identifier naming the parameter at position index,
@@ -315,15 +327,13 @@ func (r *calleeReach) paramTypeAt(call *ast.CallExpr, index int) (types.Type, bo
 	if typ == nil {
 		return nil, false
 	}
-	unaliased := types.Unalias(typ)
-	sig, ok := unaliased.(*types.Signature)
-	if !ok {
-		// A defined function type -- e.g. a named type used for a struct
-		// field or variable -- is not itself a *types.Signature, but its
-		// underlying type is, and the argument still binds to that
-		// signature's parameter the same way.
-		sig, ok = unaliased.Underlying().(*types.Signature)
-	}
+	// Underlying rather than a direct assertion, because a defined function
+	// type -- the shape a struct field holding a helper usually has -- is a
+	// *types.Named that Unalias leaves alone, and the argument still binds to
+	// its underlying signature's parameter the same way. Rejecting it would
+	// leave every call through such a field unanswered for no reason. A
+	// *types.Signature is its own underlying type, so the one call covers both.
+	sig, ok := types.Unalias(typ).Underlying().(*types.Signature)
 	if !ok {
 		return nil, false
 	}

--- a/calleereach.go
+++ b/calleereach.go
@@ -62,6 +62,22 @@ func newCalleeReach(pass *analysis.Pass) *calleeReach {
 // returned for every shape whose binding is not a plain parameter of a
 // package-level function this pass can read.
 func (r *calleeReach) follow(call *ast.CallExpr, index int) (cReach, bool) {
+	// A parameter that is not a *qt.C answers the question by its type alone.
+	//
+	// Defer and Done are C's own methods. A callee that receives the checker as
+	// a testing.TB -- or as any interface C satisfies -- cannot name them, so
+	// the hazard this rule guards is unreachable there whatever the body does,
+	// and the body does not have to be readable for that to hold. It closes the
+	// shapes no body-reading can: a function value in a struct field, a
+	// parameter of a callee from another package, a locally bound closure.
+	//
+	// The test-scoped methods are a different matter and stay conservative:
+	// Cleanup, TempDir, Setenv and the rest belong to testing.TB itself, so a
+	// TB-typed parameter reaches them and -only-stable-fixes must still say so.
+	if param, ok := r.paramTypeAt(call, index); ok && !isQuicktestCType(param) {
+		return cReach{testScoped: true, handedOn: true}, true
+	}
+
 	ident, ok := stripParens(call.Fun).(*ast.Ident)
 	if !ok {
 		return cReach{}, false
@@ -184,6 +200,7 @@ func (r *calleeReach) bodyReach(fn *ast.FuncDecl, paramObj types.Object) (cReach
 func (r *cReach) merge(other cReach) {
 	r.deferred = r.deferred || other.deferred
 	r.testScoped = r.testScoped || other.testScoped
+	r.handedOn = r.handedOn || other.handedOn
 	if r.method == "" {
 		r.method = other.method
 	}
@@ -256,4 +273,28 @@ func followedCallReach(callees *calleeReach, parent ast.Node, ident *ast.Ident) 
 		return cReach{}, false
 	}
 	return callees.follow(call, index)
+}
+
+// paramTypeAt returns the declared type of the parameter the argument at index
+// binds to, and false when the callee has no signature or the position runs
+// into a variadic tail.
+func (r *calleeReach) paramTypeAt(call *ast.CallExpr, index int) (types.Type, bool) {
+	typ := r.pass.TypesInfo.TypeOf(call.Fun)
+	if typ == nil {
+		return nil, false
+	}
+	sig, ok := types.Unalias(typ).(*types.Signature)
+	if !ok {
+		return nil, false
+	}
+	params := sig.Params()
+	if params == nil || index >= params.Len() {
+		return nil, false
+	}
+	if sig.Variadic() && index >= params.Len()-1 {
+		// Packed into a slice, so the parameter's declared type is not what the
+		// argument binds to.
+		return nil, false
+	}
+	return params.At(index).Type(), true
 }

--- a/qtlint.go
+++ b/qtlint.go
@@ -1212,8 +1212,9 @@ func isQuicktestCType(t types.Type) bool {
 	if t == nil {
 		return false
 	}
+	t = types.Unalias(t)
 	if ptr, ok := t.(*types.Pointer); ok {
-		t = ptr.Elem()
+		t = types.Unalias(ptr.Elem())
 	}
 
 	named, ok := t.(*types.Named)

--- a/requiretestingrun.go
+++ b/requiretestingrun.go
@@ -649,6 +649,11 @@ type cReach struct {
 	// scope is the test rather than the assertion.
 	deferred   bool
 	testScoped bool
+	// handedOn is set when the reach was decided by a parameter's TYPE rather
+	// than by reading a body: the checker crossed into something that is not a
+	// *qt.C, so Defer is unreachable there and testing.TB's own methods are
+	// what remains.
+	handedOn bool
 
 	// escape names the first use the analysis could not follow, and method the
 	// first spelled-out method that decided the reach. Exactly one is usually
@@ -756,6 +761,10 @@ func (r cReach) withholdReason(onlyStableFixes bool) string {
 	case r.deferred:
 		return "; no fix: the closure calls c." + r.method +
 			", and a bare qt.New(t) supplies no Done() the way C.Run does"
+	case onlyStableFixes && r.testScoped && r.handedOn:
+		return "; no fix under -only-stable-fixes: the closure hands its *qt.C to a" +
+			" parameter that is not one, so what it can reach there is testing.TB's" +
+			" own methods, which bind to whichever test the *qt.C came from"
 	case onlyStableFixes && r.testScoped:
 		return "; no fix under -only-stable-fixes: the closure calls c." + r.method +
 			", which binds to whichever test the *qt.C came from"

--- a/testdata/src/aliascontains/aliascontains.go
+++ b/testdata/src/aliascontains/aliascontains.go
@@ -13,7 +13,7 @@ import (
 func TestStringsContainsWithAlias(t *testing.T) {
 	c := qt.New(t)
 	str := "hello world"
-	
+
 	qt.Assert(t, mystrings.Contains(str, "world"), qt.IsTrue) // want "qtlint: use qt.Contains instead of mystrings.Contains\\(x, y\\), qt.IsTrue"
 	c.Assert(mystrings.Contains(str, "foo"), qt.IsFalse)      // want "qtlint: use qt.Not\\(qt.Contains\\) instead of mystrings.Contains\\(x, y\\), qt.IsFalse"
 }
@@ -22,8 +22,7 @@ func TestStringsContainsWithAlias(t *testing.T) {
 func TestSlicesContainsWithAlias(t *testing.T) {
 	c := qt.New(t)
 	slice := []int{1, 2, 3}
-	
-	qt.Assert(t, myslices.Contains(slice, 2), qt.IsTrue)   // want "qtlint: use qt.Contains instead of myslices.Contains\\(x, y\\), qt.IsTrue"
-	c.Assert(myslices.Contains(slice, 99), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.Contains\\) instead of myslices.Contains\\(x, y\\), qt.IsFalse"
-}
 
+	qt.Assert(t, myslices.Contains(slice, 2), qt.IsTrue) // want "qtlint: use qt.Contains instead of myslices.Contains\\(x, y\\), qt.IsTrue"
+	c.Assert(myslices.Contains(slice, 99), qt.IsFalse)   // want "qtlint: use qt.Not\\(qt.Contains\\) instead of myslices.Contains\\(x, y\\), qt.IsFalse"
+}

--- a/testdata/src/aliascontainsfix/aliascontainsfix.go
+++ b/testdata/src/aliascontainsfix/aliascontainsfix.go
@@ -13,7 +13,7 @@ import (
 func TestStringsContainsWithAlias(t *testing.T) {
 	c := qt.New(t)
 	str := "hello world"
-	
+
 	qt.Assert(t, mystrings.Contains(str, "world"), qt.IsTrue) // want "qtlint: use qt.Contains instead of mystrings.Contains\\(x, y\\), qt.IsTrue"
 	c.Assert(mystrings.Contains(str, "foo"), qt.IsFalse)      // want "qtlint: use qt.Not\\(qt.Contains\\) instead of mystrings.Contains\\(x, y\\), qt.IsFalse"
 }
@@ -22,8 +22,7 @@ func TestStringsContainsWithAlias(t *testing.T) {
 func TestSlicesContainsWithAlias(t *testing.T) {
 	c := qt.New(t)
 	slice := []int{1, 2, 3}
-	
-	qt.Assert(t, myslices.Contains(slice, 2), qt.IsTrue)   // want "qtlint: use qt.Contains instead of myslices.Contains\\(x, y\\), qt.IsTrue"
-	c.Assert(myslices.Contains(slice, 99), qt.IsFalse)     // want "qtlint: use qt.Not\\(qt.Contains\\) instead of myslices.Contains\\(x, y\\), qt.IsFalse"
-}
 
+	qt.Assert(t, myslices.Contains(slice, 2), qt.IsTrue) // want "qtlint: use qt.Contains instead of myslices.Contains\\(x, y\\), qt.IsTrue"
+	c.Assert(myslices.Contains(slice, 99), qt.IsFalse)   // want "qtlint: use qt.Not\\(qt.Contains\\) instead of myslices.Contains\\(x, y\\), qt.IsFalse"
+}

--- a/testdata/src/github.com/frankban/quicktest/quicktest.go
+++ b/testdata/src/github.com/frankban/quicktest/quicktest.go
@@ -20,8 +20,15 @@ import (
 )
 
 // C is a quicktest checker.
+//
+// testing.TB is embedded rather than held in a named field, because a rule that
+// answers by parameter type has to see what the real type is assignable to: the
+// real C embeds it, so a *qt.C is a testing.TB, and a stub that only carried one
+// would make every such fixture fail to compile for a reason the rule under test
+// has nothing to do with. The methods below still spell out what the embedding
+// provides, so the inventory stays visible; they shadow the promoted ones.
 type C struct {
-	TB testing.TB
+	testing.TB
 }
 
 // New returns a new checker instance.

--- a/testdata/src/haslen/haslen.go
+++ b/testdata/src/haslen/haslen.go
@@ -63,6 +63,7 @@ func TestCheckLenNotEquals(t *testing.T) {
 	qt.Check(t, len(x), qt.Not(qt.Equals), 0) // want "qtlint: use qt.Not\\(qt.HasLen\\) instead of len\\(x\\), qt.Not\\(qt.Equals\\)"
 	c.Check(len(x), qt.Not(qt.Equals), 0)     // want "qtlint: use qt.Not\\(qt.HasLen\\) instead of len\\(x\\), qt.Not\\(qt.Equals\\)"
 }
+
 // Test case: len(x) with checkers other than qt.Equals or qt.Not(qt.Equals)
 func TestLenWithOtherCheckers(t *testing.T) {
 	c := qt.New(t)

--- a/testdata/src/qtcreceiverfix/qtcreceiverfix.go
+++ b/testdata/src/qtcreceiverfix/qtcreceiverfix.go
@@ -17,8 +17,8 @@ func TestExistingC(t *testing.T) {
 
 // Case 2: a *qt.C is created once, however many assertions need it.
 func TestNoC(t *testing.T) {
-	qt.Assert(t, 1, qt.Equals, 1)                        // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
-	qt.Check(t, 2, qt.Equals, 2)                         // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
+	qt.Assert(t, 1, qt.Equals, 1)                       // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
+	qt.Check(t, 2, qt.Equals, 2)                        // want "qtlint: use c.Check\\(...\\) instead of qt.Check\\(t, ...\\)"
 	qt.Assert(t, 3, qt.Equals, 3, qt.Commentf("third")) // want "qtlint: use c.Assert\\(...\\) instead of qt.Assert\\(t, ...\\)"
 }
 

--- a/testdata/src/testingrunfix/testingrunfix.go
+++ b/testdata/src/testingrunfix/testingrunfix.go
@@ -166,6 +166,49 @@ func TestIndirectDeferWithheldByDefault(t *testing.T) {
 	})
 }
 
+// Deferrer is the shape of an interface *qt.C satisfies without being one:
+// its method set names Defer and Done, the same two methods (*qt.C)
+// declares. A parameter of this shape can still call them on whatever
+// *qt.C is handed to it, so the type-only shortcut that treats a non-*qt.C
+// parameter as safe must not fire for it.
+type Deferrer interface {
+	Defer(func())
+	Done()
+}
+
+// deferThroughInterface reaches Defer through an interface parameter rather
+// than a *qt.C one.
+func deferThroughInterface(d Deferrer) { d.Defer(func() {}) }
+
+// Defer reached through an interface parameter is withheld exactly as Defer
+// reached through a *qt.C parameter is: the parameter is not a *qt.C, but
+// its method set names the same hazard.
+func TestIndirectDeferThroughInterfaceWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		deferThroughInterface(c)
+	})
+}
+
+// AliasedC is a type alias for qt.C rather than a new named type, so a
+// *AliasedC parameter and a *qt.C parameter name the same underlying type.
+// The pointer's element still has to be unaliased for isQuicktestCType to
+// see through the alias to (*qt.C).
+type AliasedC = qt.C
+
+// deferThroughAliasedC reaches Defer through a pointer to the type alias
+// rather than through *qt.C spelled directly.
+func deferThroughAliasedC(c *AliasedC) { c.Defer(func() {}) }
+
+// Defer reached through the type alias is withheld exactly as Defer reached
+// through *qt.C spelled directly is: the two name the same type.
+func TestIndirectDeferThroughAliasWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		deferThroughAliasedC(c)
+	})
+}
+
 // The *qt.C is followed through a var declaration as well as through :=, and
 // this is the case that pins which way round that matters. The alias only ever
 // has Assert called on it, so nothing is withheld and the site keeps its fix.

--- a/testdata/src/testingrunfix/testingrunfix.go.golden
+++ b/testdata/src/testingrunfix/testingrunfix.go.golden
@@ -169,6 +169,49 @@ func TestIndirectDeferWithheldByDefault(t *testing.T) {
 	})
 }
 
+// Deferrer is the shape of an interface *qt.C satisfies without being one:
+// its method set names Defer and Done, the same two methods (*qt.C)
+// declares. A parameter of this shape can still call them on whatever
+// *qt.C is handed to it, so the type-only shortcut that treats a non-*qt.C
+// parameter as safe must not fire for it.
+type Deferrer interface {
+	Defer(func())
+	Done()
+}
+
+// deferThroughInterface reaches Defer through an interface parameter rather
+// than a *qt.C one.
+func deferThroughInterface(d Deferrer) { d.Defer(func() {}) }
+
+// Defer reached through an interface parameter is withheld exactly as Defer
+// reached through a *qt.C parameter is: the parameter is not a *qt.C, but
+// its method set names the same hazard.
+func TestIndirectDeferThroughInterfaceWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		deferThroughInterface(c)
+	})
+}
+
+// AliasedC is a type alias for qt.C rather than a new named type, so a
+// *AliasedC parameter and a *qt.C parameter name the same underlying type.
+// The pointer's element still has to be unaliased for isQuicktestCType to
+// see through the alias to (*qt.C).
+type AliasedC = qt.C
+
+// deferThroughAliasedC reaches Defer through a pointer to the type alias
+// rather than through *qt.C spelled directly.
+func deferThroughAliasedC(c *AliasedC) { c.Defer(func() {}) }
+
+// Defer reached through the type alias is withheld exactly as Defer reached
+// through *qt.C spelled directly is: the two name the same type.
+func TestIndirectDeferThroughAliasWithheldByDefault(t *testing.T) {
+	c := qt.New(t)
+	c.Run("sub", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		deferThroughAliasedC(c)
+	})
+}
+
 // The *qt.C is followed through a var declaration as well as through :=, and
 // this is the case that pins which way round that matters. The alias only ever
 // has Assert called on it, so nothing is withheld and the site keeps its fix.

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -144,6 +144,11 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Assert(holder.take(c), qt.Equals, "x")
 	})
 
+	c.Run("handle through a named function type", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure hands its \\*qt.C to a parameter that is not one, so what it can reach there is testing.TB's own methods, which bind to whichever test the \\*qt.C came from"
+		holder := namedHandlerHolder{take: handleHelper}
+		c.Assert(holder.take(c), qt.Equals, "x")
+	})
+
 	c.Run("plain helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c.Assert(plainHelper(c), qt.Equals, "x")
 	})
@@ -178,4 +183,17 @@ func handleHelper(handle any) string { return "x" }
 // body-reading can follow -- and does not need to, for the same reason.
 type opaqueHandleHolder struct {
 	take func(handle any) string
+}
+
+// Handler is a defined function type wrapping the same parameter shape
+// opaqueHandleHolder's plain func field already exercises. paramTypeAt has
+// to see through the name to its underlying signature to still answer by
+// parameter type when the field's type is not itself a function literal
+// type.
+type Handler func(handle any) string
+
+// namedHandlerHolder hands the checker to a function value held through a
+// defined function type rather than an unnamed one.
+type namedHandlerHolder struct {
+	take Handler
 }

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -149,6 +149,15 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Assert(holder.take(c), qt.Equals, "x")
 	})
 
+	c.Run("interface that declares Defer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		c.Assert(deferringHelper(c), qt.Equals, "x")
+	})
+
+	c.Run("alias behind a function value", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to holder.take\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
+		holder := opaqueAliasHolder{take: aliasDeferrer}
+		c.Assert(holder.take(c), qt.Equals, "x")
+	})
+
 	c.Run("plain helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c.Assert(plainHelper(c), qt.Equals, "x")
 	})
@@ -171,18 +180,51 @@ func TestOnlyStableFixesNamesTheFlag(t *testing.T) {
 	})
 }
 
-// handleHelper takes something that is not a checker.
-//
-// The parameter is `any` rather than testing.TB only because this package's
-// quicktest carries TB as a field rather than embedding it; the rule turns on
-// the parameter not being a *qt.C, which is what makes (*qt.C).Defer
-// unnameable inside whatever it is.
-func handleHelper(handle any) string { return "x" }
+// handleHelper takes the checker as a testing.TB, which is the case the type
+// answer exists for: Defer and Done are C's own, so nothing inside can name
+// them however the body is written, while Cleanup, TempDir and Setenv come
+// from TB itself and keep the fix withheld under -only-stable-fixes.
+func handleHelper(handle testing.TB) string { return "x" }
 
 // opaqueHandleHolder hands the checker to a function value, which no
 // body-reading can follow -- and does not need to, for the same reason.
 type opaqueHandleHolder struct {
-	take func(handle any) string
+	take func(handle testing.TB) string
+}
+
+// deferrer declares Defer itself, so a *qt.C handed to it has Defer called on
+// it without the callee ever naming *qt.C.
+//
+// This is why the type answer asks the method set rather than the identity. A
+// rule asking "is this parameter a checker" answers no here, calls the hazard
+// unreachable, and rewrites a subtest whose deferred function then never runs
+// -- silently, because nothing fails.
+type deferrer interface {
+	Defer(f func())
+	Done()
+}
+
+func deferringHelper(d deferrer) string {
+	d.Defer(func() {})
+	return "x"
+}
+
+// cAlias spells C by another name, so *cAlias IS *qt.C. The method set answers
+// that correctly however the alias is written, where an identity check that
+// did not resolve it would not.
+type cAlias = qt.C
+
+// aliasTaker puts the alias behind a function value, so the fixture turns on
+// the type answer alone: there is no body to fall back on.
+type aliasTaker func(c *cAlias) string
+
+type opaqueAliasHolder struct {
+	take aliasTaker
+}
+
+func aliasDeferrer(c *cAlias) string {
+	c.Defer(func() {})
+	return "x"
 }
 
 // Handler is a defined function type wrapping the same parameter shape
@@ -190,7 +232,7 @@ type opaqueHandleHolder struct {
 // to see through the name to its underlying signature to still answer by
 // parameter type when the field's type is not itself a function literal
 // type.
-type Handler func(handle any) string
+type Handler func(handle testing.TB) string
 
 // namedHandlerHolder hands the checker to a function value held through a
 // defined function type rather than an unnamed one.

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go
@@ -135,6 +135,15 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Assert(opaqueHolder{}.take(c), qt.Not(qt.Equals), "")
 	})
 
+	c.Run("handle helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure hands its \\*qt.C to a parameter that is not one, so what it can reach there is testing.TB's own methods, which bind to whichever test the \\*qt.C came from"
+		c.Assert(handleHelper(c), qt.Equals, "x")
+	})
+
+	c.Run("handle through a function value", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure hands its \\*qt.C to a parameter that is not one, so what it can reach there is testing.TB's own methods, which bind to whichever test the \\*qt.C came from"
+		holder := opaqueHandleHolder{take: handleHelper}
+		c.Assert(holder.take(c), qt.Equals, "x")
+	})
+
 	c.Run("plain helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c.Assert(plainHelper(c), qt.Equals, "x")
 	})
@@ -155,4 +164,18 @@ func TestOnlyStableFixesNamesTheFlag(t *testing.T) {
 		c.Cleanup(func() {})
 		c.Assert(1, qt.Equals, 1)
 	})
+}
+
+// handleHelper takes something that is not a checker.
+//
+// The parameter is `any` rather than testing.TB only because this package's
+// quicktest carries TB as a field rather than embedding it; the rule turns on
+// the parameter not being a *qt.C, which is what makes (*qt.C).Defer
+// unnameable inside whatever it is.
+func handleHelper(handle any) string { return "x" }
+
+// opaqueHandleHolder hands the checker to a function value, which no
+// body-reading can follow -- and does not need to, for the same reason.
+type opaqueHandleHolder struct {
+	take func(handle any) string
 }

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -137,6 +137,15 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Assert(opaqueHolder{}.take(c), qt.Not(qt.Equals), "")
 	})
 
+	c.Run("handle helper", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure hands its \\*qt.C to a parameter that is not one, so what it can reach there is testing.TB's own methods, which bind to whichever test the \\*qt.C came from"
+		c.Assert(handleHelper(c), qt.Equals, "x")
+	})
+
+	c.Run("handle through a function value", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure hands its \\*qt.C to a parameter that is not one, so what it can reach there is testing.TB's own methods, which bind to whichever test the \\*qt.C came from"
+		holder := opaqueHandleHolder{take: handleHelper}
+		c.Assert(holder.take(c), qt.Equals, "x")
+	})
+
 	t.Run("plain helper", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c := qt.New(t)
 		c.Assert(plainHelper(c), qt.Equals, "x")
@@ -158,4 +167,18 @@ func TestOnlyStableFixesNamesTheFlag(t *testing.T) {
 		c.Cleanup(func() {})
 		c.Assert(1, qt.Equals, 1)
 	})
+}
+
+// handleHelper takes something that is not a checker.
+//
+// The parameter is `any` rather than testing.TB only because this package's
+// quicktest carries TB as a field rather than embedding it; the rule turns on
+// the parameter not being a *qt.C, which is what makes (*qt.C).Defer
+// unnameable inside whatever it is.
+func handleHelper(handle any) string { return "x" }
+
+// opaqueHandleHolder hands the checker to a function value, which no
+// body-reading can follow -- and does not need to, for the same reason.
+type opaqueHandleHolder struct {
+	take func(handle any) string
 }

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -101,7 +101,6 @@ func TestNestedUnstableOuter(t *testing.T) {
 	})
 }
 
-
 // scopedHelper takes the checker and calls a test-scoped method on it. The
 // rule reads its body rather than guessing, so the closure that calls it is
 // withheld for what the helper actually does.
@@ -151,6 +150,15 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Assert(holder.take(c), qt.Equals, "x")
 	})
 
+	c.Run("interface that declares Defer", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the closure calls c.Defer, and a bare qt.New\\(t\\) supplies no Done\\(\\) the way C.Run does"
+		c.Assert(deferringHelper(c), qt.Equals, "x")
+	})
+
+	c.Run("alias behind a function value", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix: the \\*qt.C is handed to holder.take\\(\\.\\.\\.\\), so what it can reach includes \\(\\*qt.C\\).Defer, which panics unless Done\\(\\) ran — give that function a \\*testing.T instead and this converts"
+		holder := opaqueAliasHolder{take: aliasDeferrer}
+		c.Assert(holder.take(c), qt.Equals, "x")
+	})
+
 	t.Run("plain helper", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c := qt.New(t)
 		c.Assert(plainHelper(c), qt.Equals, "x")
@@ -174,18 +182,51 @@ func TestOnlyStableFixesNamesTheFlag(t *testing.T) {
 	})
 }
 
-// handleHelper takes something that is not a checker.
-//
-// The parameter is `any` rather than testing.TB only because this package's
-// quicktest carries TB as a field rather than embedding it; the rule turns on
-// the parameter not being a *qt.C, which is what makes (*qt.C).Defer
-// unnameable inside whatever it is.
-func handleHelper(handle any) string { return "x" }
+// handleHelper takes the checker as a testing.TB, which is the case the type
+// answer exists for: Defer and Done are C's own, so nothing inside can name
+// them however the body is written, while Cleanup, TempDir and Setenv come
+// from TB itself and keep the fix withheld under -only-stable-fixes.
+func handleHelper(handle testing.TB) string { return "x" }
 
 // opaqueHandleHolder hands the checker to a function value, which no
 // body-reading can follow -- and does not need to, for the same reason.
 type opaqueHandleHolder struct {
-	take func(handle any) string
+	take func(handle testing.TB) string
+}
+
+// deferrer declares Defer itself, so a *qt.C handed to it has Defer called on
+// it without the callee ever naming *qt.C.
+//
+// This is why the type answer asks the method set rather than the identity. A
+// rule asking "is this parameter a checker" answers no here, calls the hazard
+// unreachable, and rewrites a subtest whose deferred function then never runs
+// -- silently, because nothing fails.
+type deferrer interface {
+	Defer(f func())
+	Done()
+}
+
+func deferringHelper(d deferrer) string {
+	d.Defer(func() {})
+	return "x"
+}
+
+// cAlias spells C by another name, so *cAlias IS *qt.C. The method set answers
+// that correctly however the alias is written, where an identity check that
+// did not resolve it would not.
+type cAlias = qt.C
+
+// aliasTaker puts the alias behind a function value, so the fixture turns on
+// the type answer alone: there is no body to fall back on.
+type aliasTaker func(c *cAlias) string
+
+type opaqueAliasHolder struct {
+	take aliasTaker
+}
+
+func aliasDeferrer(c *cAlias) string {
+	c.Defer(func() {})
+	return "x"
 }
 
 // Handler is a defined function type wrapping the same parameter shape
@@ -193,7 +234,7 @@ type opaqueHandleHolder struct {
 // to see through the name to its underlying signature to still answer by
 // parameter type when the field's type is not itself a function literal
 // type.
-type Handler func(handle any) string
+type Handler func(handle testing.TB) string
 
 // namedHandlerHolder hands the checker to a function value held through a
 // defined function type rather than an unnamed one.

--- a/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
+++ b/testdata/src/testingrunonlystable/testingrunonlystable.go.golden
@@ -146,6 +146,11 @@ func TestWithholdingNamesItsCause(t *testing.T) {
 		c.Assert(holder.take(c), qt.Equals, "x")
 	})
 
+	c.Run("handle through a named function type", func(c *qt.C) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run; no fix under -only-stable-fixes: the closure hands its \\*qt.C to a parameter that is not one, so what it can reach there is testing.TB's own methods, which bind to whichever test the \\*qt.C came from"
+		holder := namedHandlerHolder{take: handleHelper}
+		c.Assert(holder.take(c), qt.Equals, "x")
+	})
+
 	t.Run("plain helper", func(t *testing.T) { // want "qtlint: use t.Run with a per-subtest qt.New instead of c.Run"
 		c := qt.New(t)
 		c.Assert(plainHelper(c), qt.Equals, "x")
@@ -181,4 +186,17 @@ func handleHelper(handle any) string { return "x" }
 // body-reading can follow -- and does not need to, for the same reason.
 type opaqueHandleHolder struct {
 	take func(handle any) string
+}
+
+// Handler is a defined function type wrapping the same parameter shape
+// opaqueHandleHolder's plain func field already exercises. paramTypeAt has
+// to see through the name to its underlying signature to still answer by
+// parameter type when the field's type is not itself a function literal
+// type.
+type Handler func(handle any) string
+
+// namedHandlerHolder hands the checker to a function value held through a
+// defined function type rather than an unnamed one.
+type namedHandlerHolder struct {
+	take Handler
 }


### PR DESCRIPTION
`Defer` and `Done` are `(*qt.C)`'s own methods. A callee that receives the checker as a `testing.TB` — or as any type `C` merely satisfies — **cannot name them**, so the hazard `-require-testing-run` guards is unreachable there whatever the body does.

That is a proof from the signature. It needs no body, which is exactly why it reaches what #75's body-reading cannot.

## What it unblocks

Measured on a project whose test tables carry `env func(testing.TB)` fields:

| contour | fixable before | fixable after |
| --- | --- | --- |
| untagged | 1 | **14** |
| tagged | 79 | **107** |

The remaining withholdings were concentrated in three shapes no body-reading can follow, and all three are answered by the signature instead: a function value held in a struct field, a closure bound to a local variable, and a callee from another package.

## What stays conservative

`Cleanup`, `TempDir`, `Setenv` and the rest belong to `testing.TB` itself, so a TB-typed parameter **does** reach them. `-only-stable-fixes` still withholds for that, and the reason now says which of the two kinds of withholding it is rather than naming a method nobody wrote:

```
no fix under -only-stable-fixes: the closure hands its *qt.C to a parameter that is
not one, so what it can reach there is testing.TB's own methods, which bind to
whichever test the *qt.C came from
```

## Fixtures

One per shape body-reading cannot follow: a plain call, and a function value in a struct field. Disabling the type answer reddens both.

Their parameter is `any` rather than `testing.TB`, and the reason is worth reading. This repository's quicktest fixture declares `type C struct { TB testing.TB }` — a **field**, not an embedded interface — so its `*C` does not satisfy `testing.TB` and a `testing.TB` parameter would not compile in a fixture. The rule turns on the parameter not being a `*qt.C`, and `any` is that.

That difference briefly looked like the premise being wrong, so it was measured rather than reasoned about: real quicktest embeds the interface, and `var tb testing.TB = qt.New(t)` compiles against v1.14.6 on go1.26.5.

`go test ./...` and `golangci-lint run ./...` are green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis of test helpers receiving non-checker parameters, providing more accurate reachability results.
  * Preserved conservative handling for checker-specific parameters.
  * Improved `-only-stable-fixes` diagnostics to clarify when methods are associated with the originating test.
  * Added support for calls made through function values and opaque helper paths.

* **Tests**
  * Added coverage for direct and indirect parameter-passing scenarios.
  * Updated formatting and expanded expected diagnostic checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->